### PR TITLE
Use generic backend config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,4 @@ COPY . ./
 
 RUN go build
 
-FROM alpine
-
-WORKDIR /app
-
-COPY --from=build /src/terraform-cloud-workspace-action ./
-
-ENTRYPOINT ["./terraform-cloud-workspace-action"]
+ENTRYPOINT ["/src/terraform-cloud-workspace-action"]

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,11 @@ inputs:
   aws_region:
     description: S3 bucket region
     required: true
+outputs:
+  plan:
+    description: Human readable Terraform plan
+  plan_json:
+    description: JSON plan
 runs:
   using: docker
   image: Dockerfile

--- a/action.yml
+++ b/action.yml
@@ -22,21 +22,6 @@ inputs:
   environments:
     description: Environments to create multiple workspaces
     default: ""
-  aws_role:
-    description: Role with permission to access the S3 storage bucket
-    required: true
-  aws_access_key:
-    description: Access key for a user with permission to assume the AWS storage role
-    required: true
-  aws_secret_key:
-    description: Secret key for a user with permission to assume the AWS storage role
-    required: true
-  aws_storage_bucket:
-    description: S3 bucket ARN to store Terraform state
-    required: true
-  aws_region:
-    description: S3 bucket region
-    required: true
   backend_config:
     description: Backend config block
     default: ""

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,9 @@ inputs:
   aws_region:
     description: S3 bucket region
     required: true
+  backend_config:
+    description: Backend config block
+    default: ""
 outputs:
   plan:
     description: Human readable Terraform plan

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,6 @@ go 1.16
 
 require (
 	github.com/hashicorp/terraform-exec v0.14.0 // indirect
+	github.com/hashicorp/terraform-json v0.12.0 // indirect
 	github.com/sethvargo/go-githubactions v0.4.0
 )

--- a/main.go
+++ b/main.go
@@ -128,7 +128,6 @@ resource "tfe_workspace" "workspace" {
 			log.Fatalf("error converting plan to json: %s", err)
 		}
 
-		fmt.Println(string(b))
 		githubactions.SetOutput("plan_json", string(b))
 
 		fmt.Println("Applying...")

--- a/main.go
+++ b/main.go
@@ -93,6 +93,7 @@ resource "tfe_workspace" "workspace" {
 		tfexec.Var(fmt.Sprintf("name=%s", githubactions.GetInput("name"))),
 		tfexec.Var(fmt.Sprintf("organization=%s", githubactions.GetInput("terraform_organization"))),
 		tfexec.Var(fmt.Sprintf("terraform_version=%s", githubactions.GetInput("terraform_version"))),
+		tfexec.Out("plan.txt"),
 	)
 
 	if err != nil {
@@ -100,7 +101,14 @@ resource "tfe_workspace" "workspace" {
 	}
 
 	if diff {
-		fmt.Println("Plan is not empty")
+		p, err := tf.ShowPlanFileRaw(context.Background(), "plan.txt")
+		if err != nil {
+			log.Fatalf("Error showing plan: %s", err)
+		}
+
+		fmt.Println(p)
+	} else {
+		fmt.Println("No changes")
 	}
 
 	err = tf.Apply(

--- a/main.go
+++ b/main.go
@@ -43,8 +43,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	workDir := path.Join(os.Getenv("GITHUB_WORKSPACE"), "tmp", githubactions.GetInput("name"))
-	err = os.Mkdir(workDir, 0755)
+	workDir, err := ioutil.TempDir("", githubactions.GetInput("name"))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/main.go
+++ b/main.go
@@ -122,18 +122,19 @@ resource "tfe_workspace" "workspace" {
 
 		fmt.Println(string(b))
 		githubactions.SetOutput("plan_json", string(b))
+
+		err = tf.Apply(
+			context.Background(),
+			tfexec.Var(fmt.Sprintf("name=%s", githubactions.GetInput("name"))),
+			tfexec.Var(fmt.Sprintf("organization=%s", githubactions.GetInput("terraform_organization"))),
+			tfexec.Var(fmt.Sprintf("terraform_version=%s", githubactions.GetInput("terraform_version"))),
+		)
+
+		if err != nil {
+			log.Fatalf("error running apply: %s", err)
+		}
 	} else {
 		fmt.Println("No changes")
 	}
 
-	err = tf.Apply(
-		context.Background(),
-		tfexec.Var(fmt.Sprintf("name=%s", githubactions.GetInput("name"))),
-		tfexec.Var(fmt.Sprintf("organization=%s", githubactions.GetInput("terraform_organization"))),
-		tfexec.Var(fmt.Sprintf("terraform_version=%s", githubactions.GetInput("terraform_version"))),
-	)
-
-	if err != nil {
-		log.Fatalf("error running apply: %s", err)
-	}
 }

--- a/main.go
+++ b/main.go
@@ -82,17 +82,17 @@ resource "tfe_workspace" "workspace" {
 		"\n",
 	)
 
-	var backendOpts []tfexec.InitOption
+	var backendConfigs []tfexec.InitOption
 	for _, val := range bcfg {
-		backendOpts = append(
-			backendOpts,
+		backendConfigs = append(
+			backendConfigs,
 			tfexec.BackendConfig(val),
 		)
 	}
 
 	err = tf.Init(
 		context.Background(),
-		backendOpts...,
+		backendConfigs...,
 	)
 	if err != nil {
 		log.Fatalf("error running Init: %s", err)
@@ -105,7 +105,6 @@ resource "tfe_workspace" "workspace" {
 		tfexec.Var(fmt.Sprintf("organization=%s", githubactions.GetInput("terraform_organization"))),
 		tfexec.Var(fmt.Sprintf("terraform_version=%s", githubactions.GetInput("terraform_version"))),
 	)
-
 	if err != nil {
 		log.Fatalf("error running plan: %s", err)
 	}
@@ -132,18 +131,17 @@ resource "tfe_workspace" "workspace" {
 		fmt.Println(string(b))
 		githubactions.SetOutput("plan_json", string(b))
 
+		fmt.Println("Applying...")
 		err = tf.Apply(
 			context.Background(),
 			tfexec.Var(fmt.Sprintf("name=%s", githubactions.GetInput("name"))),
 			tfexec.Var(fmt.Sprintf("organization=%s", githubactions.GetInput("terraform_organization"))),
 			tfexec.Var(fmt.Sprintf("terraform_version=%s", githubactions.GetInput("terraform_version"))),
 		)
-
 		if err != nil {
 			log.Fatalf("error running apply: %s", err)
 		}
 	} else {
 		fmt.Println("No changes")
 	}
-
 }


### PR DESCRIPTION
Updates the action to use a more generic backend config. This works great for all backends except terraform cloud, which has trouble because it uses nested keys to in it's config, although I'm having trouble finding the issue now. 

Additionally, adds the plan to stdout and as github outputs (both json and human readable). 

Fianlly, removed the interesting docker double build because the action was having issues. We will revisit the build in a different PR.

Example usage:
```
    steps:
        ...
        with:
          ...
          backend_config: |-
            access_key=${{ secrets.AWS_ACCESS_KEY_ID }}
            secret_key=${{ secrets.AWS_SECRET_ACCESS_KEY }}
            role_arn=${{ secrets.AWS_STORAGE_ROLE }}
            bucket=${{ secrets.AWS_STORAGE_BUCKET }}
            key=${{ github.event.repository.name }}/terraform.tfstate
            region=us-west-2
```