### PR TITLE
Add workspace support

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,13 +14,13 @@ inputs:
     description: Terraform Cloud organization
     required: true
   name:
-    description: Name of the workspace
+    description: Name of the workspace. Becomes a prefix if workspaces are passed (`${name}-${workspace}`)
     default: "${{ github.event.repository.name }}"
   runner_terraform_version:
     description: Terraform version used to create the workspace
     default: "1.0.3"
-  environments:
-    description: Environments to create multiple workspaces
+  workspaces:
+    description: Comma separated list of workspaces
     default: ""
   backend_config:
     description: Backend config block

--- a/main.go
+++ b/main.go
@@ -116,7 +116,10 @@ resource "tfe_workspace" "workspace" {
 	for _, s := range strings.Split(githubactions.GetInput("workspaces"), ",") {
 		workspaces = append(workspaces, strings.TrimSpace(s))
 	}
-	wsBytes, _ := json.Marshal(workspaces)
+	wsBytes, err := json.Marshal(workspaces)
+	if err != nil {
+		log.Fatalf("error marshalling workspaces input: %s", err)
+	}
 
 	diff, err := tf.Plan(
 		context.Background(),


### PR DESCRIPTION
Takes a comma separated workspaces list from the actions in put, splits it out into a slice then turns that into a string representation so it can be passed via cli -var to Terraform. I played around with passing the comma separated string all the way through to tf but it seemed better to have the workspace accept the types that it expects.