### PR TITLE
Add VCS integration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.16
+
+    - name: Test
+      run: go test -v ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
 
-  build:
+  test:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,16 @@ inputs:
   import:
     description: Whether to attempt to import existing matching resources using the resource name
     default: false
+  vcs_name:
+    description: Terraform VCS client name. Superseded by `vcs_token_id`. If neither are passed, no VCS integration is added.
+  vcs_token_id: 
+    description: Terraform VCS client token ID. Takes precedence over `vcs_name`. If neither are passed, no VCS integration is added.
+  vcs_repo:
+    description: Repository identifier for a VCS integration. Required if `vcs_name` or `vcs_token_id` are passed
+    default: "${{ github.repository }}"
+  vcs_ingress_submodules:
+    description: Whether to allow submodule ingress
+    default: false
 outputs:
   plan:
     description: Human readable Terraform plan

--- a/action.yml
+++ b/action.yml
@@ -31,8 +31,8 @@ inputs:
   import:
     description: Whether to attempt to import existing matching resources using the resource name
     default: false
-  vcs_name:
-    description: Terraform VCS client name. Superseded by `vcs_token_id`. If neither are passed, no VCS integration is added.
+  vcs_type:
+    description: Terraform VCS type to find a token for ("github"). Superseded by `vcs_token_id`. If neither are passed, no VCS integration is added.
   vcs_token_id: 
     description: Terraform VCS client token ID. Takes precedence over `vcs_name`. If neither are passed, no VCS integration is added.
   vcs_repo:

--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ inputs:
     description: Whether to attempt to import existing matching resources using the resource name
     default: false
   vcs_type:
-    description: Terraform VCS type to find a token for ("github"). Superseded by `vcs_token_id`. If neither are passed, no VCS integration is added.
+    description: Terraform VCS type (e.g., "github"). Superseded by `vcs_token_id`. If neither are passed, no VCS integration is added.
   vcs_token_id: 
     description: Terraform VCS client token ID. Takes precedence over `vcs_name`. If neither are passed, no VCS integration is added.
   vcs_repo:

--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/hashicorp/go-tfe v0.17.1
 	github.com/hashicorp/terraform-exec v0.14.0
 	github.com/sethvargo/go-githubactions v0.4.0
+	gotest.tools v2.2.0+incompatible
 )

--- a/go.sum
+++ b/go.sum
@@ -148,6 +148,7 @@ github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -296,6 +297,8 @@ gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
+gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ func main() {
 	host := githubactions.GetInput("terraform_host")
 	name := strings.TrimSpace(githubactions.GetInput("name"))
 	org := githubactions.GetInput("terraform_organization")
-	vcsName := githubactions.GetInput("vcs_name")
+	vcsType := githubactions.GetInput("vcs_type")
 	vcsTokenID := githubactions.GetInput("vcs_token_id")
 	vcsRepo := githubactions.GetInput("vcs_repo")
 
@@ -70,9 +70,9 @@ func main() {
 	}
 
 	vcsBlock := ""
-	if vcsName != "" || vcsTokenID != "" {
+	if vcsType != "" || vcsTokenID != "" {
 		if vcsTokenID == "" {
-			vcsTokenID, err = GetVCSTokenIDByClientName(context.Background(), client, org, vcsName)
+			vcsTokenID, err = GetVCSTokenIDByClientType(context.Background(), client, org, vcsType)
 			if err != nil {
 				log.Fatalf("Failed to find VCS client: %s", err)
 			}

--- a/main.go
+++ b/main.go
@@ -23,6 +23,17 @@ func main() {
 	host := githubactions.GetInput("terraform_host")
 	name := strings.TrimSpace(githubactions.GetInput("name"))
 	org := githubactions.GetInput("terraform_organization")
+	vcsName := githubactions.GetInput("vcs_name")
+	vcsTokenID := githubactions.GetInput("vcs_token_id")
+	vcsRepo := githubactions.GetInput("vcs_repo")
+
+	client, err := tfe.NewClient(&tfe.Config{
+		Address: fmt.Sprintf("https://%s", host),
+		Token:   token,
+	})
+	if err != nil {
+		log.Fatalf("error configuring Terraform client: %s", err)
+	}
 
 	tmpDir, err := ioutil.TempDir("", "tfinstall")
 	if err != nil {
@@ -58,7 +69,18 @@ func main() {
 		log.Fatal(err)
 	}
 
-	b = []byte(`
+	vcsBlock := ""
+	if vcsName != "" || vcsTokenID != "" {
+		if vcsTokenID == "" {
+			vcsTokenID, err = GetVCSTokenIDByClientName(context.Background(), client, org, vcsName)
+			if err != nil {
+				log.Fatalf("Failed to find VCS client: %s", err)
+			}
+		}
+		vcsBlock = FormatVCSBlock(vcsTokenID, vcsRepo, inputs.GetBool("vcs_ingress_submodules"))
+	}
+
+	b = []byte(fmt.Sprintf(`
 terraform {
 	backend "s3" {}
 }
@@ -80,8 +102,10 @@ resource "tfe_workspace" "workspace" {
 	organization      = var.organization
 	auto_apply        = true
 	terraform_version = var.terraform_version
+
+	%s
 }
-`)
+`, vcsBlock))
 
 	err = ioutil.WriteFile(path.Join(workDir, "main.tf"), b, 0644)
 	if err != nil {
@@ -137,14 +161,6 @@ resource "tfe_workspace" "workspace" {
 
 	if inputs.GetBool("import") {
 		fmt.Println("Importing resources...")
-
-		client, err := tfe.NewClient(&tfe.Config{
-			Address: fmt.Sprintf("https://%s", host),
-			Token:   token,
-		})
-		if err != nil {
-			log.Fatalf("error configuring Terraform client: %s", err)
-		}
 
 		opts := make([]tfexec.ImportOption, len(varOpts))
 		for i, v := range varOpts {

--- a/main.go
+++ b/main.go
@@ -23,9 +23,6 @@ func main() {
 	host := githubactions.GetInput("terraform_host")
 	name := strings.TrimSpace(githubactions.GetInput("name"))
 	org := githubactions.GetInput("terraform_organization")
-	vcsType := githubactions.GetInput("vcs_type")
-	vcsTokenID := githubactions.GetInput("vcs_token_id")
-	vcsRepo := githubactions.GetInput("vcs_repo")
 
 	client, err := tfe.NewClient(&tfe.Config{
 		Address: fmt.Sprintf("https://%s", host),
@@ -68,6 +65,10 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	vcsType := githubactions.GetInput("vcs_type")
+	vcsTokenID := githubactions.GetInput("vcs_token_id")
+	vcsRepo := githubactions.GetInput("vcs_repo")
 
 	vcsBlock := ""
 	if vcsType != "" || vcsTokenID != "" {

--- a/vcs.go
+++ b/vcs.go
@@ -18,8 +18,8 @@ func FormatVCSBlock(VCStokenID string, repo string, ingressSubmodules bool) stri
 `, VCStokenID, repo, ingressSubmodules)
 }
 
-// getVCSClientByName looks for a VCS client of the passed name against the VCS clients in the Terraform Cloud organization
-func getVCSClientByName(ctx context.Context, tfc *tfe.Client, organization string, vcsName string) (*tfe.OAuthClient, error) {
+// getVCSClientByName looks for a VCS client of the passed type against the VCS clients in the Terraform Cloud organization
+func getVCSClientByName(ctx context.Context, tfc *tfe.Client, organization string, vcsType string) (*tfe.OAuthClient, error) {
 	list, err := tfc.OAuthClients.List(ctx, organization, tfe.OAuthClientListOptions{
 		ListOptions: tfe.ListOptions{
 			PageSize: 100,
@@ -30,17 +30,17 @@ func getVCSClientByName(ctx context.Context, tfc *tfe.Client, organization strin
 	}
 
 	for _, v := range list.Items {
-		if v.ServiceProviderName == vcsName {
+		if v.ServiceProvider == tfe.ServiceProviderType(vcsType) {
 			return v, nil
 		}
 	}
 
-	return nil, fmt.Errorf("no VCS Client found named %s", vcsName)
+	return nil, fmt.Errorf("no VCS Client found named %s", vcsType)
 }
 
-// GetVCSTokenIDByClientName returns an OAuth client token ID for the passed VCS client name
-func GetVCSTokenIDByClientName(ctx context.Context, tfc *tfe.Client, organization string, vcsName string) (string, error) {
-	vcsClient, err := getVCSClientByName(ctx, tfc, organization, vcsName)
+// GetVCSTokenIDByClientType returns an OAuth client token ID for the passed VCS type
+func GetVCSTokenIDByClientType(ctx context.Context, tfc *tfe.Client, organization string, vcsType string) (string, error) {
+	vcsClient, err := getVCSClientByName(ctx, tfc, organization, vcsType)
 	if err != nil {
 		return "", err
 	}

--- a/vcs.go
+++ b/vcs.go
@@ -13,7 +13,7 @@ func FormatVCSBlock(VCStokenID string, repo string, ingressSubmodules bool) stri
   vcs_repo {
     oauth_token_id     = %q
     identifier         = %q
-		ingress_submodules = %t
+    ingress_submodules = %t
   }
 `, VCStokenID, repo, ingressSubmodules)
 }

--- a/vcs.go
+++ b/vcs.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	tfe "github.com/hashicorp/go-tfe"
+)
+
+// FormatVCSBlock formats a vcs_repo block
+func FormatVCSBlock(VCStokenID string, repo string, ingressSubmodules bool) string {
+	return fmt.Sprintf(`
+  vcs_repo {
+    oauth_token_id     = %q
+    identifier         = %q
+		ingress_submodules = %t
+  }
+`, VCStokenID, repo, ingressSubmodules)
+}
+
+// getVCSClientByName looks for a VCS client of the passed name against the VCS clients in the Terraform Cloud organization
+func getVCSClientByName(ctx context.Context, tfc *tfe.Client, organization string, vcsName string) (*tfe.OAuthClient, error) {
+	list, err := tfc.OAuthClients.List(ctx, organization, tfe.OAuthClientListOptions{
+		ListOptions: tfe.ListOptions{
+			PageSize: 100,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, v := range list.Items {
+		if v.ServiceProviderName == vcsName {
+			return v, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no VCS Client found named %s", vcsName)
+}
+
+// GetVCSTokenIDByClientName returns an OAuth client token ID for the passed VCS client name
+func GetVCSTokenIDByClientName(ctx context.Context, tfc *tfe.Client, organization string, vcsName string) (string, error) {
+	vcsClient, err := getVCSClientByName(ctx, tfc, organization, vcsName)
+	if err != nil {
+		return "", err
+	}
+
+	if len(vcsClient.OAuthTokens) == 0 {
+		return "", fmt.Errorf("no VCS tokens found for client %s:%s", vcsClient.ServiceProviderName, vcsClient.ID)
+	}
+
+	return vcsClient.OAuthTokens[0].ID, nil
+}

--- a/vcs_test.go
+++ b/vcs_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	tfe "github.com/hashicorp/go-tfe"
+	"gotest.tools/assert"
+)
+
+func TestGetVCSTokenIDByClientType(t *testing.T) {
+	ctx := context.Background()
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+
+	defer server.Close()
+
+	mux.HandleFunc("/api/v2/organizations/org/oauth-clients", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+
+		_, err := fmt.Fprint(w, `
+			{
+				"data": [
+					{
+						"id": "oc-sdlkfjdskljfsd",
+						"type": "oauth-clients",
+						"attributes": {
+							"name": "github.com",
+							"created-at": "2021-04-12T21:14:17.245Z",
+							"callback-url": "https://app.terraform.io/auth/12345/callback",
+							"connect-path": "/auth/12345?organization_id=12345",
+							"service-provider": "github",
+							"service-provider-display-name": "GitHub",
+							"http-url": "https://github.com",
+							"api-url": "https://api.github.com",
+							"key": "12345",
+							"secret": null,
+							"rsa-public-key": null
+						},
+						"relationships": {
+							"organization": {
+								"data": {
+									"id": "org",
+									"type": "organizations"
+								},
+								"links": {
+									"related": "/api/v2/organizations/org"
+								}
+							},
+							"oauth-tokens": {
+								"data": [
+									{
+										"id": "ot-678910",
+										"type": "oauth-tokens"
+									}
+								],
+								"links": {
+									"related": "/api/v2/oauth-clients/oc-sdlkfjdskljfsd/oauth-tokens"
+								}
+							}
+						}
+					}
+				]
+			}
+		`)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	client, err := tfe.NewClient(&tfe.Config{
+		Address: server.URL,
+		Token:   "12345",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("get client by type", func(t *testing.T) {
+		tokenID, err := GetVCSTokenIDByClientType(ctx, client, "org", "github")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Equal(t, tokenID, "ot-678910")
+	})
+}

--- a/vcs_test.go
+++ b/vcs_test.go
@@ -80,7 +80,7 @@ func TestGetVCSTokenIDByClientType(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	t.Run("get client by type", func(t *testing.T) {
+	t.Run("get client token ID by type", func(t *testing.T) {
 		tokenID, err := GetVCSTokenIDByClientType(ctx, client, "org", "github")
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
Couple notes:

- The Terraform Cloud client doesn't return the VCS name noted in the API model `attributes`, only the [service provider type and service provider display name](https://github.com/hashicorp/go-tfe/blob/main/oauth_client.go#L74-L75). I think it's probably okay to just go with the first provider of a specific type given that we have an override with passing vcs_token_id directly.
- The templating feels weird. I'm thinking we should move towards constructing the file in json instead (`main.tf.json`).