### PR TITLE
Add support for variables

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,10 @@ inputs:
   import:
     description: Whether to attempt to import existing matching resources using the resource name
     default: false
+  variables:
+    description: YAML encoded variables to apply to all workspaces
+  workspace_variables:
+    description: YAML encoded variables to apply to specific workspaces, with variables nested under workspace names
 outputs:
   plan:
     description: Human readable Terraform plan

--- a/action.yml
+++ b/action.yml
@@ -33,8 +33,10 @@ inputs:
     default: false
   variables:
     description: YAML encoded variables to apply to all workspaces
+    default: ""
   workspace_variables:
     description: YAML encoded variables to apply to specific workspaces, with variables nested under workspace names
+    default: ""
   vcs_type:
     description: Terraform VCS type (e.g., "github"). Superseded by `vcs_token_id`. If neither are passed, no VCS integration is added.
   vcs_token_id: 

--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/hashicorp/go-tfe v0.17.1
 	github.com/hashicorp/terraform-exec v0.14.0
 	github.com/sethvargo/go-githubactions v0.4.0
+	gopkg.in/yaml.v2 v2.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -126,9 +126,11 @@ github.com/klauspost/compress v1.11.2 h1:MiK62aErc3gIiVEtyzKfeOHgW7atJb5g/KNX5m3
 github.com/klauspost/compress v1.11.2/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
 github.com/matryer/is v1.2.0/go.mod h1:2fLPjFQM9rhQ15aVEtbuwhJinnOqrmgXPNdZsdwlWXA=
@@ -287,12 +289,14 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/cheggaaa/pb.v1 v1.0.27/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/importer.go
+++ b/importer.go
@@ -8,8 +8,7 @@ import (
 	"github.com/hashicorp/terraform-exec/tfexec"
 )
 
-var pageSize int = 100
-var startingPage int = 1
+var maxPageSize int = 100
 
 func shouldImport(ctx context.Context, tf *tfexec.Terraform, address string) (bool, error) {
 	state, err := tf.Show(ctx)
@@ -63,7 +62,7 @@ func ImportWorkspace(ctx context.Context, tf *tfexec.Terraform, tfc *tfe.Client,
 func fetchVariableByKey(ctx context.Context, client *tfe.Client, key string, workspaceID string, page int) (*tfe.Variable, error) {
 	vs, err := client.Variables.List(ctx, workspaceID, tfe.VariableListOptions{
 		ListOptions: tfe.ListOptions{
-			PageSize: pageSize,
+			PageSize: maxPageSize,
 		},
 	})
 	if err != nil {
@@ -103,7 +102,7 @@ func ImportVariable(ctx context.Context, tf *tfexec.Terraform, client *tfe.Clien
 		return err
 	}
 
-	v, err := fetchVariableByKey(ctx, client, key, ws.ID, startingPage)
+	v, err := fetchVariableByKey(ctx, client, key, ws.ID, 1)
 	if err != nil {
 		return err
 	}

--- a/importer.go
+++ b/importer.go
@@ -57,7 +57,7 @@ func ImportWorkspace(ctx context.Context, tf *tfexec.Terraform, tfc *tfe.Client,
 	return nil
 }
 
-func getVariableByKey(ctx context.Context, client *tfe.Client, key string, workspaceID string, page int) (*tfe.Variable, error) {
+func fetchVariableByKey(ctx context.Context, client *tfe.Client, key string, workspaceID string, page int) (*tfe.Variable, error) {
 	vs, err := client.Variables.List(ctx, workspaceID, tfe.VariableListOptions{
 		ListOptions: tfe.ListOptions{
 			PageSize: 100,
@@ -76,7 +76,7 @@ func getVariableByKey(ctx context.Context, client *tfe.Client, key string, works
 	fmt.Println(vs.NextPage)
 
 	if vs.NextPage > page {
-		return getVariableByKey(ctx, client, key, workspaceID, vs.NextPage)
+		return fetchVariableByKey(ctx, client, key, workspaceID, vs.NextPage)
 	}
 
 	return nil, nil
@@ -100,7 +100,7 @@ func ImportVariable(ctx context.Context, tf *tfexec.Terraform, client *tfe.Clien
 		return err
 	}
 
-	v, err := getVariableByKey(ctx, client, key, ws.ID, 1)
+	v, err := fetchVariableByKey(ctx, client, key, ws.ID, 1)
 	if err != nil {
 		return err
 	}

--- a/importer.go
+++ b/importer.go
@@ -92,7 +92,7 @@ func ImportVariable(ctx context.Context, tf *tfexec.Terraform, client *tfe.Clien
 	}
 
 	if !imp {
-		fmt.Printf("Variable %q already exists in state, skipping import\n", key)
+		fmt.Printf("Variable %q already exists in state, skipping import\n", address)
 		return nil
 	}
 

--- a/importer.go
+++ b/importer.go
@@ -76,11 +76,6 @@ func fetchVariableByKey(ctx context.Context, client *tfe.Client, key string, wor
 		}
 	}
 
-	fmt.Println("next page", vs.NextPage)
-	fmt.Println("total page:", vs.TotalPages)
-	fmt.Println("current page:", vs.CurrentPage)
-	fmt.Println("page:", page)
-
 	if vs.NextPage > page {
 		return fetchVariableByKey(ctx, client, key, workspaceID, vs.NextPage)
 	}
@@ -119,11 +114,13 @@ func ImportVariable(ctx context.Context, tf *tfexec.Terraform, client *tfe.Clien
 	}
 
 	importID := fmt.Sprintf("%s/%s/%s", organization, workspace, v.ID)
+
 	err = tf.Import(ctx, address, importID, opts...)
 	if err != nil {
 		return err
 	}
 
 	fmt.Printf("Variable %q successfully imported\n", importID)
+
 	return nil
 }

--- a/importer.go
+++ b/importer.go
@@ -56,3 +56,65 @@ func ImportWorkspace(ctx context.Context, tf *tfexec.Terraform, tfc *tfe.Client,
 
 	return nil
 }
+
+func getVariableByKey(ctx context.Context, client *tfe.Client, key string, workspaceID string, page int) (*tfe.Variable, error) {
+	vs, err := client.Variables.List(ctx, workspaceID, tfe.VariableListOptions{
+		ListOptions: tfe.ListOptions{
+			PageSize: 100,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, v := range vs.Items {
+		if v.Key == key {
+			return v, nil
+		}
+	}
+
+	fmt.Println(vs.NextPage)
+
+	if vs.NextPage > page {
+		return getVariableByKey(ctx, client, key, workspaceID, vs.NextPage)
+	}
+
+	return nil, nil
+}
+
+func ImportVariable(ctx context.Context, tf *tfexec.Terraform, client *tfe.Client, key string, workspace string, organization string, opts ...tfexec.ImportOption) error {
+	address := fmt.Sprintf("tfe_variable.vars[\"%s-%s\"]", workspace, key)
+
+	imp, err := shouldImport(ctx, tf, address)
+	if err != nil {
+		return err
+	}
+
+	if !imp {
+		fmt.Printf("Variable %q already exists in state, skipping import\n", key)
+		return nil
+	}
+
+	ws, err := client.Workspaces.Read(ctx, organization, workspace)
+	if err != nil {
+		return err
+	}
+
+	v, err := getVariableByKey(ctx, client, key, ws.ID, 1)
+	if err != nil {
+		return err
+	}
+
+	if v == nil {
+		fmt.Printf("Variable %q for workspace %q not found, skipping import\n", key, workspace)
+		return nil
+	}
+
+	err = tf.Import(ctx, address, v.ID, opts...)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Variable %q for workspace %q successfully imported\n", key, workspace)
+	return nil
+}

--- a/importer.go
+++ b/importer.go
@@ -76,6 +76,11 @@ func fetchVariableByKey(ctx context.Context, client *tfe.Client, key string, wor
 		}
 	}
 
+	fmt.Println("next page", vs.NextPage)
+	fmt.Println("total page:", vs.TotalPages)
+	fmt.Println("current page:", vs.CurrentPage)
+	fmt.Println("page:", page)
+
 	if vs.NextPage > page {
 		return fetchVariableByKey(ctx, client, key, workspaceID, vs.NextPage)
 	}
@@ -96,6 +101,8 @@ func ImportVariable(ctx context.Context, tf *tfexec.Terraform, client *tfe.Clien
 		return nil
 	}
 
+	fmt.Printf("Importing variable: %q\n", address)
+
 	ws, err := client.Workspaces.Read(ctx, organization, workspace)
 	if err != nil {
 		return err
@@ -111,11 +118,12 @@ func ImportVariable(ctx context.Context, tf *tfexec.Terraform, client *tfe.Clien
 		return nil
 	}
 
-	err = tf.Import(ctx, address, v.ID, opts...)
+	importID := fmt.Sprintf("%s/%s/%s", organization, workspace, v.ID)
+	err = tf.Import(ctx, address, importID, opts...)
 	if err != nil {
 		return err
 	}
 
-	fmt.Printf("Variable %q for workspace %q successfully imported\n", key, workspace)
+	fmt.Printf("Variable %q successfully imported\n", importID)
 	return nil
 }

--- a/importer.go
+++ b/importer.go
@@ -8,6 +8,9 @@ import (
 	"github.com/hashicorp/terraform-exec/tfexec"
 )
 
+var pageSize int = 100
+var startingPage int = 1
+
 func shouldImport(ctx context.Context, tf *tfexec.Terraform, address string) (bool, error) {
 	state, err := tf.Show(ctx)
 	if err != nil {
@@ -60,7 +63,7 @@ func ImportWorkspace(ctx context.Context, tf *tfexec.Terraform, tfc *tfe.Client,
 func fetchVariableByKey(ctx context.Context, client *tfe.Client, key string, workspaceID string, page int) (*tfe.Variable, error) {
 	vs, err := client.Variables.List(ctx, workspaceID, tfe.VariableListOptions{
 		ListOptions: tfe.ListOptions{
-			PageSize: 100,
+			PageSize: pageSize,
 		},
 	})
 	if err != nil {
@@ -72,8 +75,6 @@ func fetchVariableByKey(ctx context.Context, client *tfe.Client, key string, wor
 			return v, nil
 		}
 	}
-
-	fmt.Println(vs.NextPage)
 
 	if vs.NextPage > page {
 		return fetchVariableByKey(ctx, client, key, workspaceID, vs.NextPage)
@@ -100,7 +101,7 @@ func ImportVariable(ctx context.Context, tf *tfexec.Terraform, client *tfe.Clien
 		return err
 	}
 
-	v, err := fetchVariableByKey(ctx, client, key, ws.ID, 1)
+	v, err := fetchVariableByKey(ctx, client, key, ws.ID, startingPage)
 	if err != nil {
 		return err
 	}

--- a/importer.go
+++ b/importer.go
@@ -83,7 +83,7 @@ func fetchVariableByKey(ctx context.Context, client *tfe.Client, key string, wor
 }
 
 func ImportVariable(ctx context.Context, tf *tfexec.Terraform, client *tfe.Client, key string, workspace string, organization string, opts ...tfexec.ImportOption) error {
-	address := fmt.Sprintf("tfe_variable.vars[\"%s-%s\"]", workspace, key)
+	address := fmt.Sprintf("tfe_variable.variables[\"%s-%s\"]", workspace, key)
 
 	imp, err := shouldImport(ctx, tf, address)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -197,8 +197,6 @@ func main() {
 		log.Fatalf("Failed marshal vars: %s", err)
 	}
 
-	fmt.Println(string(varBytes))
-
 	wsBytes, err := json.Marshal(workspaces)
 	if err != nil {
 		log.Fatalf("error marshalling workspaces input: %s", err)
@@ -223,6 +221,13 @@ func main() {
 			err = ImportWorkspace(context.Background(), tf, client, name, org, opts...)
 			if err != nil {
 				log.Fatal(err)
+			}
+		}
+
+		for _, v := range vars {
+			err = ImportVariable(context.Background(), tf, client, v.Key, v.WorkspaceName, org, opts...)
+			if err != nil {
+				log.Fatalf("Error importing variables: %s\n", err)
 			}
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-exec/tfexec"
 	"github.com/hashicorp/terraform-exec/tfinstall"
 	"github.com/sethvargo/go-githubactions"
+	yaml "gopkg.in/yaml.v2"
 
 	"github.com/takescoop/terraform-cloud-workspace-action/internal/inputs"
 )
@@ -86,7 +87,7 @@ func main() {
 		}
 	}
 
-	cfg := WorkspaceConfig{
+	b, err = json.MarshalIndent(WorkspaceConfig{
 		Terraform: WorkspaceTerraform{
 			Backend: WorkspaceBackend{
 				S3: S3BackendConfig{},
@@ -102,10 +103,13 @@ func main() {
 			"workspace_names": {
 				Type: "set(string)",
 			},
+			"variables": {
+				Type: "set(map(string))",
+			},
 		},
-		Resources: map[string]map[string]WorkspaceResource{
+		Resources: map[string]map[string]interface{}{
 			"tfe_workspace": {
-				"workspace": {
+				"workspace": WorkspaceWorkspaceResource{
 					ForEach:          "${var.workspace_names}",
 					Name:             "${each.value}",
 					Organization:     "${var.organization}",
@@ -114,10 +118,18 @@ func main() {
 					VCSRepo:          vcs,
 				},
 			},
+			"tfe_variable": {
+				"variables": WorkspaceVariableResource{
+					ForEach:     "${{ for k, v in var.variables : \"${v.workspace_name}-${v.key}\" => v }}",
+					Description: "${each.value.description}",
+					Key:         "${each.value.key}",
+					Value:       "${each.value.value}",
+					Category:    "${each.value.category}",
+					WorkspaceID: "${tfe_workspace.workspace[each.value.workspace_name].id}",
+				},
+			},
 		},
-	}
-
-	b, err = json.MarshalIndent(cfg, "", "\t")
+	}, "", "\t")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -163,6 +175,30 @@ func main() {
 		}
 	}
 
+	genVars := []Variable{}
+	err = yaml.Unmarshal([]byte(githubactions.GetInput("variables")), &genVars)
+	if err != nil {
+		log.Fatalf("Failed to parse variables %s", err)
+	}
+
+	wsVars := map[string][]Variable{}
+	err = yaml.Unmarshal([]byte(githubactions.GetInput("workspace_variables")), &wsVars)
+	if err != nil {
+		log.Fatalf("Failed to parse workspace variables %s", err)
+	}
+
+	vars, err := ParseVariablesByWorkspace(workspaces, &genVars, &wsVars)
+	if err != nil {
+		log.Fatalf("Failed to parse variables: %s", err)
+	}
+
+	varBytes, err := json.Marshal(vars)
+	if err != nil {
+		log.Fatalf("Failed marshal vars: %s", err)
+	}
+
+	fmt.Println(string(varBytes))
+
 	wsBytes, err := json.Marshal(workspaces)
 	if err != nil {
 		log.Fatalf("error marshalling workspaces input: %s", err)
@@ -172,6 +208,7 @@ func main() {
 		tfexec.Var(fmt.Sprintf("organization=%s", org)),
 		tfexec.Var(fmt.Sprintf("terraform_version=%s", githubactions.GetInput("terraform_version"))),
 		tfexec.Var(fmt.Sprintf("workspace_names=%s", string(wsBytes))),
+		tfexec.Var(fmt.Sprintf("variables=%s", string(varBytes))),
 	}
 
 	if inputs.GetBool("import") {

--- a/main.go
+++ b/main.go
@@ -72,6 +72,9 @@ variable "terraform_version" {
 variable "workspace_names" {
 	type = set(string)
 }
+variable "variables" {
+	type = set(map(string))
+}
 
 resource "tfe_workspace" "workspace" {
 	for_each = var.workspace_names
@@ -80,6 +83,16 @@ resource "tfe_workspace" "workspace" {
 	organization      = var.organization
 	auto_apply        = true
 	terraform_version = var.terraform_version
+}
+
+resource "tfe_variables" "vars" {
+	for_each = { for k, v in var.variables : "${v.workspace}-${v.key}" => v }
+
+  description  = each.value.description
+	key          = each.value.key
+  value        = each.value.value
+  category     = each.value.category
+  workspace_id = tfe_workspace.workspaces[each.value.workspace].id
 }
 `)
 

--- a/variables.go
+++ b/variables.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"github.com/sethvargo/go-githubactions"
+	yaml "gopkg.in/yaml.v2"
+)
+
+type customVariable struct {
+	key         string `yaml:"key"`
+	value       string `yaml:"value"`
+	description string `yaml:"description,omitempty" default:""`
+	category    string `yaml:"category,omitempty" default:"env"`
+	sensitive   bool   `yaml:"sensitive,omitempty" default:true`
+}
+
+func ParseVariableInput() {
+	vars := githubactions.GetInput("variables")
+
+	yaml.Unmarshal([]bytes(`foo`))
+}

--- a/variables_test.go
+++ b/variables_test.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+type WorkspaceTestCase struct {
+	Name               string
+	Workspaces         []string
+	Variables          []Variable
+	WorkspaceVariables map[string][]Variable
+	AssertEqual        []Variable
+}
+
+func sortVariables(slice []Variable) {
+	sort.Slice(slice[:], func(i, j int) bool {
+		return fmt.Sprintf("%s-%s", slice[i].WorkspaceName, slice[i].Key) < fmt.Sprintf("%s-%s", slice[j].WorkspaceName, slice[j].Key)
+	})
+}
+
+func TestParseVariablesByWorkspace(t *testing.T) {
+	workspaceTestCases := []WorkspaceTestCase{
+		{
+			Name:               "apply single variable to single workspace",
+			Workspaces:         []string{"staging"},
+			Variables:          []Variable{{Key: "foo", Value: "bar"}},
+			WorkspaceVariables: map[string][]Variable{},
+			AssertEqual: []Variable{{
+				Key:           "foo",
+				Value:         "bar",
+				WorkspaceName: "staging",
+				Category:      "env",
+			}},
+		},
+		{
+			Name:       "apply multiple variables to single workspace",
+			Workspaces: []string{"staging"},
+			Variables: []Variable{
+				{Key: "foo", Value: "bar"},
+				{Key: "baz", Value: "woz"},
+			},
+			WorkspaceVariables: map[string][]Variable{},
+			AssertEqual: []Variable{
+				{
+					Key:           "baz",
+					Value:         "woz",
+					WorkspaceName: "staging",
+					Category:      "env",
+				},
+				{
+					Key:           "foo",
+					Value:         "bar",
+					WorkspaceName: "staging",
+					Category:      "env",
+				},
+			},
+		},
+		{
+			Name:               "apply nothing when variables or workspace variables are passed",
+			Workspaces:         []string{"staging"},
+			Variables:          []Variable{},
+			WorkspaceVariables: map[string][]Variable{},
+			AssertEqual:        []Variable{},
+		},
+		{
+			Name:               "apply variables to all workspaces",
+			Workspaces:         []string{"staging", "production"},
+			Variables:          []Variable{{Key: "foo", Value: "bar"}},
+			WorkspaceVariables: map[string][]Variable{},
+			AssertEqual: []Variable{
+				{
+					Key:           "foo",
+					Value:         "bar",
+					WorkspaceName: "production",
+					Category:      "env",
+				},
+				{
+					Key:           "foo",
+					Value:         "bar",
+					WorkspaceName: "staging",
+					Category:      "env",
+				},
+			},
+		},
+		{
+			Name:       "apply workspace variables to named workspaces",
+			Workspaces: []string{"staging", "production"},
+			Variables:  []Variable{},
+			WorkspaceVariables: map[string][]Variable{
+				"staging": {
+					{
+						Key:   "environment",
+						Value: "staging",
+					},
+				},
+				"production": {
+					{
+						Key:   "environment",
+						Value: "production",
+					},
+				},
+			},
+			AssertEqual: []Variable{
+				{
+					Key:           "environment",
+					Value:         "staging",
+					WorkspaceName: "staging",
+					Category:      "env",
+				},
+				{
+					Key:           "environment",
+					Value:         "production",
+					WorkspaceName: "production",
+					Category:      "env",
+				},
+			},
+		},
+		{
+			Name:       "apply workspace variables to single workspaces",
+			Workspaces: []string{"staging", "production"},
+			Variables:  []Variable{},
+			WorkspaceVariables: map[string][]Variable{
+				"staging": {
+					{
+						Key:   "environment",
+						Value: "staging",
+					},
+				},
+			},
+			AssertEqual: []Variable{
+				{
+					Key:           "environment",
+					Value:         "staging",
+					WorkspaceName: "staging",
+					Category:      "env",
+				},
+			},
+		},
+	}
+
+	for _, c := range workspaceTestCases {
+		t.Run(c.Name, func(t *testing.T) {
+			vars, err := ParseVariablesByWorkspace(
+				c.Workspaces,
+				&c.Variables,
+				&c.WorkspaceVariables,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			sortVariables(vars)
+			sortVariables(c.AssertEqual)
+
+			assert.DeepEqual(t, vars, c.AssertEqual)
+		})
+	}
+
+	t.Run("error when workspace variable workspace is not found in passed workspace names", func(t *testing.T) {
+		_, err := ParseVariablesByWorkspace(
+			[]string{"foo"},
+			&[]Variable{},
+			&map[string][]Variable{
+				"bar": {{
+					Key:   "should",
+					Value: "error",
+				}},
+			},
+		)
+		assert.ErrorContains(t, err, fmt.Sprintf("workspace %q was not found", "bar"))
+	})
+}

--- a/workspace.go
+++ b/workspace.go
@@ -8,9 +8,9 @@ import (
 )
 
 type WorkspaceConfig struct {
-	Terraform WorkspaceTerraform                      `json:"terraform"`
-	Variables map[string]WorkspaceVariable            `json:"variable,omitempty"`
-	Resources map[string]map[string]WorkspaceResource `json:"resource,omitempty"`
+	Terraform WorkspaceTerraform                `json:"terraform"`
+	Variables map[string]WorkspaceVariable      `json:"variable,omitempty"`
+	Resources map[string]map[string]interface{} `json:"resource,omitempty"`
 }
 
 type WorkspaceBackend struct {
@@ -35,13 +35,23 @@ type WorkspaceVCSBlock struct {
 	IngressSubmodules bool   `json:"ingress_submodules"`
 }
 
-type WorkspaceResource struct {
+type WorkspaceWorkspaceResource struct {
 	ForEach          string             `json:"for_each,omitempty"`
 	Name             string             `json:"name"`
 	Organization     string             `json:"organization"`
 	AutoApply        bool               `json:"auto_apply"`
 	TerraformVersion string             `json:"terraform_version"`
 	VCSRepo          *WorkspaceVCSBlock `json:"vcs_repo,omitempty"`
+}
+
+type WorkspaceVariableResource struct {
+	ForEach     string `json:"for_each,omitempty"`
+	Key         string `json:"key"`
+	Value       string `json:"value"`
+	Description string `json:"description,omitempty"`
+	Category    string `json:"category,omitempty"`
+	WorkspaceID string `json:"workspace_id,omitempty"`
+	Sensitive   bool   `json:"sensitive,omitempty"`
 }
 
 // getVCSClientByName looks for a VCS client of the passed type against the VCS clients in the Terraform Cloud organization

--- a/workspace_test.go
+++ b/workspace_test.go
@@ -93,7 +93,7 @@ func TestGetVCSTokenIDByClientType(t *testing.T) {
 
 func TestWorkspaceJSONRender(t *testing.T) {
 	t.Run("no VCS block added when VCSRepo is nil", func(t *testing.T) {
-		b, err := json.MarshalIndent(WorkspaceResource{
+		b, err := json.MarshalIndent(WorkspaceWorkspaceResource{
 			ForEach:          "${var.workspace_names}",
 			Name:             "${each.value}",
 			Organization:     "${var.organization}",
@@ -132,9 +132,9 @@ func TestWorkspaceJSONRender(t *testing.T) {
 					Type: "set(string)",
 				},
 			},
-			Resources: map[string]map[string]WorkspaceResource{
+			Resources: map[string]map[string]interface{}{
 				"tfe_workspace": {
-					"workspace": {
+					"workspace": WorkspaceWorkspaceResource{
 						ForEach:          "${var.workspace_names}",
 						Name:             "${each.value}",
 						Organization:     "${var.organization}",


### PR DESCRIPTION
variables and workspace variables can be passed via action inputs in a yaml block

```yaml
variables: |-
- key: foo
  value: bar
- key: baz
  value: woz
workspace_variables: |-
staging:
- key: environment
  value: staging
production:
- key: environment
  value: production
```

Variables apply to all workspaces, where workspaced variables are passed only to those workspaces that are planned to exist. 

Variables can be imported if import is true in the action inputs