### PR TITLE
Support terraform remote state

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -76,7 +76,8 @@ inputs:
   file_triggers_enabled:
     description: Whether to filter runs based on the changed files in a VCS push
     required: false
-
+  remote_state_blocks:
+    description: Remote state blocks to configure in the workspace
 outputs:
   plan:
     description: Human readable Terraform plan

--- a/action.yml
+++ b/action.yml
@@ -76,7 +76,7 @@ inputs:
   file_triggers_enabled:
     description: Whether to filter runs based on the changed files in a VCS push
     required: false
-  remote_state_blocks:
+  remote_states:
     description: Remote state blocks to configure in the workspace
 outputs:
   plan:

--- a/import.go
+++ b/import.go
@@ -83,7 +83,7 @@ func fetchVariableByKey(ctx context.Context, client *tfe.Client, key string, wor
 }
 
 func ImportVariable(ctx context.Context, tf *tfexec.Terraform, client *tfe.Client, key string, workspace string, organization string, opts ...tfexec.ImportOption) error {
-	address := fmt.Sprintf("tfe_variable.variables[\"%s-%s\"]", workspace, key)
+	address := fmt.Sprintf("tfe_variable.%s-%s", workspace, key)
 
 	imp, err := shouldImport(ctx, tf, address)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -109,7 +109,7 @@ func main() {
 
 	var remoteStates map[string]RemoteStateBlock
 
-	err = yaml.Unmarshal([]byte(githubactions.GetInput("remote_state_blocks")), &remoteStates)
+	err = yaml.Unmarshal([]byte(githubactions.GetInput("remote_states")), &remoteStates)
 	if err != nil {
 		log.Fatalf("Failed to parse remote state blocks%s", err)
 	}
@@ -161,7 +161,7 @@ func main() {
 
 	b, err = json.MarshalIndent(wsConfig, "", "\t")
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("Failed marshal workspace configuration: %s", err)
 	}
 
 	if err = ioutil.WriteFile(path.Join(workDir, "main.tf.json"), b, 0644); err != nil {

--- a/variables.go
+++ b/variables.go
@@ -5,12 +5,12 @@ import (
 )
 
 type Variable struct {
-	Key           string `yaml:"key" json:"key"`
-	Value         string `yaml:"value" json:"value"`
-	Description   string `yaml:"description,omitempty" json:"description"`
-	Category      string `yaml:"category,omitempty" json:"category"`
-	Sensitive     bool   `yaml:"sensitive,omitempty" json:"sensitive"`
-	WorkspaceName string `json:"workspace_name"`
+	Key           string `yaml:"key"`
+	Value         string `yaml:"value"`
+	Description   string `yaml:"description,omitempty"`
+	Category      string `yaml:"category,omitempty"`
+	Sensitive     bool   `yaml:"sensitive,omitempty"`
+	WorkspaceName string
 }
 
 func contains(strings []string, target string) bool {

--- a/workspace.go
+++ b/workspace.go
@@ -12,6 +12,7 @@ type WorkspaceConfig struct {
 	Terraform WorkspaceTerraform                `json:"terraform"`
 	Variables map[string]WorkspaceVariable      `json:"variable,omitempty"`
 	Resources map[string]map[string]interface{} `json:"resource,omitempty"`
+	Data      map[string]map[string]interface{} `json:"data,omitempty"`
 }
 
 type WorkspaceBackend struct {
@@ -34,6 +35,24 @@ type WorkspaceVCSBlock struct {
 	OauthTokenID      string `json:"oauth_token_id"`
 	Identifier        string `json:"identifier"`
 	IngressSubmodules bool   `json:"ingress_submodules"`
+}
+
+type RemoteStateBackendConfigWorkspaces struct {
+	Name string `json:"name"`
+}
+
+type RemoteStateBackendConfig struct {
+	Key          *string                             `json:"key,omitempty"`
+	Bucket       *string                             `json:"bucket,omitempty"`
+	Region       *string                             `json:"region,omitempty"`
+	Hostname     *string                             `json:"hostname,omitempty"`
+	Organization *string                             `json:"organization,omitempty"`
+	Workspaces   *RemoteStateBackendConfigWorkspaces `json:"workspaces,omitempty"`
+}
+
+type RemoteStateBlock struct {
+	Config  RemoteStateBackendConfig `json:"config" yaml:"config"`
+	Backend string                   `json:"backend" yaml:"backend"`
 }
 
 type WorkspaceWorkspaceResource struct {
@@ -176,4 +195,16 @@ func NewWorkspaceResource(ctx context.Context, client *tfe.Client, config Worksp
 	ws.SSHKeyID = config.SSHKeyID
 
 	return ws, nil
+}
+
+// NewWorkspaceVariableResource takes a Variable and uses it to fill a new WorkspaceVariableResource
+func NewWorkspaceVariableResource(v *Variable) *WorkspaceVariableResource {
+	return &WorkspaceVariableResource{
+		Key:         v.Key,
+		Value:       v.Value,
+		Description: v.Description,
+		Category:    v.Category,
+		Sensitive:   v.Sensitive,
+		WorkspaceID: fmt.Sprintf("${tfe_workspace.workspace[%q].id}", v.WorkspaceName),
+	}
 }


### PR DESCRIPTION
Adds support for remote state references which will be useful for accessing team names remotely for team access.

While testing out this change I came across an incompatibility with references. It seems like a nice feature to be able to add a variable via remote state to your workspace but this turns out to fail when trying to pass a reference as a value. 

To accomodate this change, the PR now adds workspace variables to the workspace struct directly instead of passing in vars and doing a for_each. 

The variable block configuration user input remains the same, with the bonus of being able to reference state outputs.

```yml
variables:
  - key: secret
    value: ${data.terraform_remote_state.foo.outputs.password}
    sensitive: true
remote_states:
  foo:
    backend: remote
    config:
      hostname: app.terraform.io
      organization: ryanwholey
      workspaces:
        name: workspace-foo
```

Also did some minor cleanup in a few places, moving 

```go
err := do()
if err != nil {
  // handle
}
```
to

```go
if err := do() ; err != nil {
  // handle
}
