### PR TITLE
Add working directory input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -42,19 +42,18 @@ inputs:
     required: false
   vcs_token_id: 
     description: Terraform VCS client token ID. Takes precedence over `vcs_name`. If neither are passed, no VCS integration is added.
-    required: false
   vcs_repo:
     description: Repository identifier for a VCS integration. Required if `vcs_name` or `vcs_token_id` are passed
     default: "${{ github.repository }}"
   vcs_ingress_submodules:
     description: Whether to allow submodule ingress
     default: false
+  working_directory:
+    description: A relative path that Terraform will execute within. Defaults to the root of your repository.
   agent_pool_id: 
     description: ID of an agent pool to assign to the workspace. If passed, execution_mode is set to "agent".
-    required: false
   execution_mode:
     description: Execution mode to use for the workspace
-    required: false
   global_remote_state: 
     description: Whether all workspaces in the organization can access the workspace via remote state
     default: false
@@ -66,16 +65,12 @@ inputs:
     default: true
   queue_all_runs:
     description: Whether the workspace should start automatically performing runs immediately after creation
-    required: false
   speculative_enabled:
     description: Whether the workspace allows speculative plans
-    required: false
   ssh_key_id:
     description: SSH key ID to assign the workspace
-    required: false
   file_triggers_enabled:
     description: Whether to filter runs based on the changed files in a VCS push
-    required: false
   remote_states:
     description: Remote state blocks to configure in the workspace
 outputs:

--- a/main.go
+++ b/main.go
@@ -83,6 +83,7 @@ func main() {
 		VCSRepo:                githubactions.GetInput("vcs_repo"),
 		VCSTokenID:             githubactions.GetInput("vcs_token_id"),
 		VCSType:                githubactions.GetInput("vcs_type"),
+		WorkingDirectory:       githubactions.GetInput("working_directory"),
 	})
 	if err != nil {
 		log.Fatalf("Error structuring workspace resource: %s", err)

--- a/workspace.go
+++ b/workspace.go
@@ -70,6 +70,7 @@ type WorkspaceWorkspaceResource struct {
 	TerraformVersion       string             `json:"terraform_version,omitempty"`
 	SSHKeyID               string             `json:"ssh_key_id,omitempty"`
 	VCSRepo                *WorkspaceVCSBlock `json:"vcs_repo,omitempty"`
+	WorkingDirectory       string             `json:"working_directory,omitempty"`
 }
 
 type WorkspaceVariableResource struct {
@@ -132,6 +133,7 @@ type WorkspaceConfigOptions struct {
 	VCSRepo                string
 	VCSTokenID             string
 	VCSType                string
+	WorkingDirectory       string
 }
 
 // NewWorkspaceResource adds defaults and conditional fields to a WorkspaceWorkspaceResource struct
@@ -193,6 +195,7 @@ func NewWorkspaceResource(ctx context.Context, client *tfe.Client, config Worksp
 	ws.SpeculativeEnabled = config.SpeculativeEnabled
 	ws.FileTriggersEnabled = config.FileTriggersEnabled
 	ws.SSHKeyID = config.SSHKeyID
+	ws.WorkingDirectory = config.WorkingDirectory
 
 	return ws, nil
 }


### PR DESCRIPTION
Somehow forgot to add this to our workspace resources! We'll for sure need this as I don't think folks would be too pleased if we put all of the terraform config in the root directory of our app repos. 

Also removed all the `required: false` inputs I added because it is the default.