### PR TITLE
Replace gotools/assert with testify

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,6 @@ require (
 	github.com/hashicorp/go-tfe v0.17.1
 	github.com/hashicorp/terraform-exec v0.14.0
 	github.com/sethvargo/go-githubactions v0.4.0
+	github.com/stretchr/testify v1.7.0
 	gopkg.in/yaml.v2 v2.4.0
-	gotest.tools/v3 v3.0.3
 )

--- a/go.sum
+++ b/go.sum
@@ -65,7 +65,6 @@ github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
-github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
@@ -151,7 +150,6 @@ github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -163,7 +161,6 @@ github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNX
 github.com/sethvargo/go-githubactions v0.4.0 h1:7bFG8WriSpdLgGGEnOsV87+9fi7+3Yen+YTZlw55nRQ=
 github.com/sethvargo/go-githubactions v0.4.0/go.mod h1:ugCoIFQjs7HxIwwYiY7ty6H9T+7Z4ey481HxqA3VRKE=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
-github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
@@ -262,7 +259,6 @@ golang.org/x/tools v0.0.0-20190312170243-e65039ee4138/go.mod h1:LCzVGOaR6xXOjkQ3
 golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190506145303-2d16b83fe98c/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190606124116-d0a3d012864b/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
-golang.org/x/tools v0.0.0-20190624222133-a101b041ded4/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190628153133-6cdbf07be9d0/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -300,14 +296,11 @@ gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gotest.tools/v3 v3.0.3 h1:4AuOwCGf4lLR9u3YOe2awrHygurzhO/HeQ6laiA6Sx0=
-gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/team_access_test.go
+++ b/team_access_test.go
@@ -3,11 +3,11 @@ package main
 import (
 	"testing"
 
-	"gotest.tools/v3/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMergeWorkspaceIDs(t *testing.T) {
-	assert.DeepEqual(t,
+	assert.Equal(t,
 		MergeWorkspaceIDs(
 			[]TeamAccess{
 				{Access: "read", TeamName: "readers"},

--- a/variables_test.go
+++ b/variables_test.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"testing"
 
-	"gotest.tools/v3/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 type WorkspaceTestCase struct {
@@ -156,7 +156,7 @@ func TestParseVariablesByWorkspace(t *testing.T) {
 			sortVariables(vars)
 			sortVariables(c.AssertEqual)
 
-			assert.DeepEqual(t, vars, c.AssertEqual)
+			assert.Equal(t, vars, c.AssertEqual)
 		})
 	}
 
@@ -171,6 +171,6 @@ func TestParseVariablesByWorkspace(t *testing.T) {
 				}},
 			},
 		)
-		assert.ErrorContains(t, err, fmt.Sprintf("workspace %q was not found", "bar"))
+		assert.EqualError(t, err, fmt.Sprintf("workspace %q was not found in planned workspaces [foo]", "bar"))
 	})
 }

--- a/workspace_test.go
+++ b/workspace_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	tfe "github.com/hashicorp/go-tfe"
-	"gotest.tools/v3/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 var basicOauthClientResponse string = `
@@ -347,7 +347,7 @@ func TestNewWorkspaceResource(t *testing.T) {
 			Organization: "org",
 			VCSType:      "github",
 		})
-		assert.ErrorContains(t, err, "VCS repository must be passed")
+		assert.EqualError(t, err, "VCS repository must be passed if VCS type or a VCS token ID is passed")
 	})
 
 	t.Run("use VCSTokenID directly when passed", func(t *testing.T) {
@@ -387,7 +387,7 @@ func TestNewWorkspaceResource(t *testing.T) {
 		}
 
 		assert.Equal(t, *ws.GlobalRemoteState, false)
-		assert.DeepEqual(t, ws.RemoteStateConsumerIDs, []string{"123", "456", "789"})
+		assert.Equal(t, ws.RemoteStateConsumerIDs, []string{"123", "456", "789"})
 	})
 
 	t.Run("add no remote IDs when none are passed", func(t *testing.T) {
@@ -400,7 +400,7 @@ func TestNewWorkspaceResource(t *testing.T) {
 		}
 
 		assert.Equal(t, *ws.GlobalRemoteState, false)
-		assert.DeepEqual(t, ws.RemoteStateConsumerIDs, []string{})
+		assert.Equal(t, ws.RemoteStateConsumerIDs, []string{})
 	})
 }
 
@@ -430,16 +430,16 @@ func TestAddTeamAccess(t *testing.T) {
 		{TeamName: "Readers", Access: "read", WorkspaceName: "workspace"},
 	}, "org")
 
-	assert.DeepEqual(t, wsConfig.Data["tfe_team"]["Writers"], TeamDataResource{
+	assert.Equal(t, wsConfig.Data["tfe_team"]["Writers"], TeamDataResource{
 		Name:         "Writers",
 		Organization: "org",
 	})
-	assert.DeepEqual(t, wsConfig.Data["tfe_team"]["Readers"], TeamDataResource{
+	assert.Equal(t, wsConfig.Data["tfe_team"]["Readers"], TeamDataResource{
 		Name:         "Readers",
 		Organization: "org",
 	})
 
-	assert.DeepEqual(t,
+	assert.Equal(t,
 		wsConfig.Resources["tfe_team_access"]["workspace-Writers"],
 		&WorkspaceTeamAccessResource{
 			TeamID:      "${data.tfe_team.Writers.id}",
@@ -447,7 +447,7 @@ func TestAddTeamAccess(t *testing.T) {
 			Access:      "write",
 		},
 	)
-	assert.DeepEqual(t,
+	assert.Equal(t,
 		wsConfig.Resources["tfe_team_access"]["workspace-Readers"],
 		&WorkspaceTeamAccessResource{
 			TeamID:      "${data.tfe_team.Readers.id}",


### PR DESCRIPTION
Replaces gotools/test with a testify replacement per previous [comments](https://github.com/TakeScoop/terraform-cloud-workspace-action/pull/20#discussion_r682963873) about the popularity of the gotools/assert lib vs some of the other third party tools out there. 