### PR TITLE
Try out actionlint

### DIFF
--- a/.github/workflows/action-lint.yml
+++ b/.github/workflows/action-lint.yml
@@ -10,4 +10,4 @@ jobs:
           curl -fsSL https://github.com/rhysd/actionlint/releases/download/v1.5.3/actionlint_1.5.3_linux_386.tar.gz -o actionlint.tgz
           sudo tar xfz actionlint.tgz -C /usr/local/bin
       - name: Check workflow files
-        run:  actionlint -color
+        run:  actionlint

--- a/.github/workflows/action-lint.yml
+++ b/.github/workflows/action-lint.yml
@@ -1,0 +1,13 @@
+name: Lint GitHub Action
+on: [push, pull_request]
+jobs:
+  action-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download actionlint
+        run: |
+          curl -fsSL https://github.com/rhysd/actionlint/releases/download/v1.5.3/actionlint_1.5.3_linux_386.tar.gz -o actionlint.tgz
+          sudo tar xfz actionlint.tgz -C /usr/local/bin
+      - name: Check workflow files
+        run:  actionlint -color

--- a/.github/workflows/action-lint.yml
+++ b/.github/workflows/action-lint.yml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Download actionlint
         run: |
-          curl -fsSL https://github.com/rhysd/actionlint/releases/download/v1.5.3/actionlint_1.5.3_linux_386.tar.gz -o actionlint.tgz
+          curl -fsSL https://github.com/rhysd/actionlint/releases/download/v1.5.3/actionlint_1.5.3_linux_amd64.tar.gz -o actionlint.tgz
           sudo tar xfz actionlint.tgz -C /usr/local/bin
       - name: Check workflow files
         run:  actionlint

--- a/.github/workflows/action-lint.yml
+++ b/.github/workflows/action-lint.yml
@@ -6,8 +6,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Download actionlint
+        env:
+          ACTIONLINT_VERSION: 1.5.3
         run: |
-          curl -fsSL https://github.com/rhysd/actionlint/releases/download/v1.5.3/actionlint_1.5.3_linux_amd64.tar.gz -o actionlint.tgz
+          curl -fsSL  -o actionlint.tgz "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
           sudo tar xfz actionlint.tgz -C /usr/local/bin
       - name: Check workflow files
         run:  actionlint

--- a/.github/workflows/action-lint.yml
+++ b/.github/workflows/action-lint.yml
@@ -1,5 +1,5 @@
 name: Lint GitHub Action
-on: [push, pull_request]
+on: [push]
 jobs:
   action-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds the [actionlint](https://github.com/rhysd/actionlint) script to lint our github action yaml. This should hopefully keep us from shooting ourselves in the foot one day. Once we are happy with this here I'll add an organization workflow for us over at `takescoop/.github`