### PR TITLE
Parse backend config as yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ jobs:
           terraform_token: "${{ secrets.TF_TOKEN }}"
           terraform_organization: "my-org"
           apply: "${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}"
+          backend_config: |-
+            s3:
+              bucket: my-bucket
+              key: foo.tfstate
+              region: us-east-1
 ```
 
 ## Inputs
@@ -27,7 +32,7 @@ jobs:
 | `terraform_token`  | (required) Terraform Cloud token | |
 | `agent_pool_id` | ID of an agent pool to assign to the workspace. If passed, execution_mode is set to "agent" | |
 | `auto_apply` | Whether to set auto_apply on the workspace or workspaces | true |
-| `backend_config` | Backend config block | `""` |
+| `backend_config` | YAML encoded backend configurations | |
 | `execution_mode` | Execution mode to use for the workspace | |
 | `file_triggers_enabled` | Whether to filter runs based on the changed files in a VCS push | |
 | `global_remote_state` | Whether all workspaces in the organization can access the workspace via remote state | `false` |
@@ -50,6 +55,23 @@ jobs:
 | `working_directory` | A relative path that Terraform will execute within. Defaults to the root of your repository | |
 | `workspace_variables` | YAML encoded variables to apply to specific workspaces, with variables nested under workspace names | `""` |
 | `workspaces` | Comma separated list of workspaces | `""` |
+
+### Backend Config
+
+This project supports two backend types, `S3` and `local`
+
+```yml
+with:
+  ...
+  backend_config: |-
+    s3:
+      bucket: my-bucket
+      key: foo.tfstate
+      region: us-east-1
+      role_arn: arn:aws:iam::123456789:role/terraform
+      access_key: xxx
+      secret_key: xxx
+```
 
 ### Variables and Workspace Variables
 

--- a/action.yml
+++ b/action.yml
@@ -23,8 +23,7 @@ inputs:
     description: Comma separated list of workspaces
     default: ""
   backend_config:
-    description: Backend config block
-    default: ""
+    description: YAML encoded backend configurations
   apply:
     description: Whether to apply the proposed Terraform changes
     required: true

--- a/backend.go
+++ b/backend.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"fmt"
+
+	yaml "gopkg.in/yaml.v2"
+)
+
+type WorkspaceBackend struct {
+	S3    *S3BackendConfig    `yaml:"s3,omitempty" json:"s3,omitempty"`
+	Local *LocalBackendConfig `yaml:"s3,omitempty" json:"local,omitempty"`
+}
+
+type S3BackendConfig struct {
+	Bucket    string `yaml:"bucket" json:"bucket"`
+	Key       string `yaml:"key" json:"key"`
+	Region    string `yaml:"region" json:"region"`
+	AccessKey string `yaml:"access_key" json:"access_key,omitempty"`
+	SecretKey string `yaml:"secret_key" json:"secret_key,omitempty"`
+	RoleArn   string `yaml:"role_arn" json:"role_arn,omitempty"`
+}
+
+type LocalBackendConfig struct {
+	Path string `json:"path,omitempty"`
+}
+
+func ParseBackend(backendInput string) (*WorkspaceBackend, error) {
+	var backend map[string]interface{}
+
+	wsBackend := &WorkspaceBackend{}
+
+	if err := yaml.Unmarshal([]byte(backendInput), &backend); err != nil {
+		return nil, err
+	}
+
+	if _, ok := backend["s3"]; ok {
+		var s3Backend map[string]S3BackendConfig
+
+		if err := yaml.Unmarshal([]byte(backendInput), &s3Backend); err != nil {
+			return nil, err
+		}
+
+		be := s3Backend["s3"]
+		wsBackend.S3 = &be
+
+		return wsBackend, nil
+	}
+
+	if _, ok := backend["local"]; ok {
+		var localBackend map[string]LocalBackendConfig
+
+		if err := yaml.Unmarshal([]byte(backendInput), &localBackend); err != nil {
+			return nil, err
+		}
+
+		be := localBackend["local"]
+		wsBackend.Local = &be
+
+		return wsBackend, nil
+	}
+
+	return nil, fmt.Errorf("unsupported backend type %v", backend)
+}

--- a/backend_test.go
+++ b/backend_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseBackend(t *testing.T) {
+	t.Run("Parse S3 backend with minimal inputs", func(t *testing.T) {
+		config := `---
+s3:
+  bucket: foo
+  key: bar
+  region: us-east-1
+`
+
+		be, err := ParseBackend(config)
+		assert.NoError(t, err)
+
+		assert.Equal(t, be.S3.Bucket, "foo")
+		assert.Equal(t, be.S3.Key, "bar")
+		assert.Equal(t, be.S3.Region, "us-east-1")
+		assert.Equal(t, be.Local, (*LocalBackendConfig)(nil))
+	})
+
+	t.Run("Parse Local backend with minimal inputs", func(t *testing.T) {
+		config := `---
+local:
+  path: foo/terraform.tfstate
+`
+
+		be, err := ParseBackend(config)
+		assert.NoError(t, err)
+
+		assert.Equal(t, be.Local.Path, "foo/terraform.tfstate")
+		assert.Equal(t, be.S3, (*S3BackendConfig)(nil))
+	})
+
+	t.Run("Error on unsupported backend type", func(t *testing.T) {
+		config := `---
+pg:
+	conn_str: postgres://user:pass@db.example.com/terraform_backend
+`
+
+		_, err := ParseBackend(config)
+		assert.Error(t, err)
+	})
+}

--- a/main.go
+++ b/main.go
@@ -150,8 +150,6 @@ func main() {
 		log.Fatalf("Failed to marshal workspace configuration: %s", err)
 	}
 
-	fmt.Println(string(b))
-
 	workDir, err := ioutil.TempDir("", name)
 	if err != nil {
 		log.Fatal(err)
@@ -165,16 +163,6 @@ func main() {
 	if err != nil {
 		log.Fatalf("error creating Terraform client: %s", err)
 	}
-
-	// bcfg := strings.Split(
-	// 	strings.TrimSpace(githubactions.GetInput("backend_config")),
-	// 	"\n",
-	// )
-
-	// var backendConfigs []tfexec.InitOption
-	// for _, val := range bcfg {
-	// 	backendConfigs = append(backendConfigs, tfexec.BackendConfig(val))
-	// }
 
 	if err = tf.Init(ctx); err != nil {
 		log.Fatalf("error running Init: %s", err)

--- a/main.go
+++ b/main.go
@@ -106,11 +106,14 @@ func main() {
 
 	teamAccess := MergeWorkspaceIDs(teamInputs, workspaces)
 
+	wsBackend, err := ParseBackend(githubactions.GetInput("backend_config"))
+	if err != nil {
+		log.Fatalf("Failed to parse backend: %s", err)
+	}
+
 	wsConfig, err := NewWorkspaceConfig(ctx, client, &NewWorkspaceConfigOptions{
 		TerraformBackendConfig: &WorkspaceTerraform{
-			Backend: WorkspaceBackend{
-				S3: &S3BackendConfig{},
-			},
+			Backend: *wsBackend,
 		},
 		WorkspaceResourceOptions: &WorkspaceResourceOptions{
 			AgentPoolID:            githubactions.GetInput("agent_pool_id"),
@@ -147,6 +150,8 @@ func main() {
 		log.Fatalf("Failed to marshal workspace configuration: %s", err)
 	}
 
+	fmt.Println(string(b))
+
 	workDir, err := ioutil.TempDir("", name)
 	if err != nil {
 		log.Fatal(err)
@@ -161,17 +166,17 @@ func main() {
 		log.Fatalf("error creating Terraform client: %s", err)
 	}
 
-	bcfg := strings.Split(
-		strings.TrimSpace(githubactions.GetInput("backend_config")),
-		"\n",
-	)
+	// bcfg := strings.Split(
+	// 	strings.TrimSpace(githubactions.GetInput("backend_config")),
+	// 	"\n",
+	// )
 
-	var backendConfigs []tfexec.InitOption
-	for _, val := range bcfg {
-		backendConfigs = append(backendConfigs, tfexec.BackendConfig(val))
-	}
+	// var backendConfigs []tfexec.InitOption
+	// for _, val := range bcfg {
+	// 	backendConfigs = append(backendConfigs, tfexec.BackendConfig(val))
+	// }
 
-	if err = tf.Init(ctx, backendConfigs...); err != nil {
+	if err = tf.Init(ctx); err != nil {
 		log.Fatalf("error running Init: %s", err)
 	}
 

--- a/workspace.go
+++ b/workspace.go
@@ -15,19 +15,8 @@ type WorkspaceConfig struct {
 	Data      map[string]map[string]interface{} `json:"data,omitempty"`
 }
 
-type WorkspaceBackend struct {
-	S3    *S3BackendConfig    `json:"s3,omitempty"`
-	Local *LocalBackendConfig `json:"local,omitempty"`
-}
-
 type WorkspaceTerraform struct {
 	Backend WorkspaceBackend `json:"backend"`
-}
-
-type S3BackendConfig struct{}
-
-type LocalBackendConfig struct {
-	Path string `json:"path,omitempty"`
 }
 
 type WorkspaceVariable struct {

--- a/workspace_test.go
+++ b/workspace_test.go
@@ -130,7 +130,11 @@ func TestWorkspaceJSONRender(t *testing.T) {
 		b, err := json.MarshalIndent(WorkspaceConfig{
 			Terraform: WorkspaceTerraform{
 				Backend: WorkspaceBackend{
-					S3: &S3BackendConfig{},
+					S3: &S3BackendConfig{
+						Bucket: "my-bucket",
+						Key:    "foo.tfstate",
+						Region: "us-east-1",
+					},
 				},
 			},
 			Variables: map[string]WorkspaceVariable{
@@ -175,7 +179,11 @@ func TestWorkspaceJSONRender(t *testing.T) {
 		assert.Equal(t, string(b), `{
 	"terraform": {
 		"backend": {
-			"s3": {}
+			"s3": {
+				"bucket": "my-bucket",
+				"key": "foo.tfstate",
+				"region": "us-east-1"
+			}
 		}
 	},
 	"variable": {


### PR DESCRIPTION
Couple changes here related to the backend config:
- Parses the input as yaml instead of splitting on newline
- Enforces a distinct backend type, which will hopefully make it easier to support new backend types in the future if needed

I was a little shaky on the best way to parse an input into distinct struct types. I went with an approach that involves parsing the input twice, once as a generic interface and the next into the desired struct type. LMK if there's a better approach here.