### PR TITLE
Resource name override

### DIFF
--- a/main.go
+++ b/main.go
@@ -150,6 +150,8 @@ func main() {
 		log.Fatalf("Failed to marshal workspace configuration: %s", err)
 	}
 
+	fmt.Println(string(b))
+
 	workDir, err := ioutil.TempDir("", name)
 	if err != nil {
 		log.Fatal(err)

--- a/main.go
+++ b/main.go
@@ -150,8 +150,6 @@ func main() {
 		log.Fatalf("Failed to marshal workspace configuration: %s", err)
 	}
 
-	fmt.Println(string(b))
-
 	workDir, err := ioutil.TempDir("", name)
 	if err != nil {
 		log.Fatal(err)

--- a/team_access.go
+++ b/team_access.go
@@ -4,6 +4,7 @@ type TeamAccess struct {
 	Access        string                 `yaml:"access,omitempty"`
 	Permissions   *TeamAccessPermissions `yaml:"permissions,omitempty"`
 	TeamName      string                 `yaml:"team_name"`
+	ResourceName  string                 `yaml:"resource_name"`
 	WorkspaceName string
 }
 
@@ -29,4 +30,12 @@ func MergeWorkspaceIDs(teamAccess []TeamAccess, workspaceNames []string) []TeamA
 	}
 
 	return ts
+}
+
+func (ta TeamAccess) GetResourceName() string {
+	if ta.ResourceName != "" {
+		return ta.ResourceName
+	}
+
+	return ta.TeamName
 }

--- a/workspace.go
+++ b/workspace.go
@@ -231,7 +231,7 @@ type WorkspaceTeamAccessResource struct {
 // NewWorkspaceTeamAccessResource takes a Team object and uses it to fill a new WorkspaceTeamAccessResource
 func NewWorkspaceTeamAccessResource(ta *TeamAccess) *WorkspaceTeamAccessResource {
 	return &WorkspaceTeamAccessResource{
-		TeamID:      fmt.Sprintf("${data.tfe_team.%s.id}", ta.TeamName),
+		TeamID:      fmt.Sprintf("${data.tfe_team.%s.id}", ta.GetResourceName()),
 		WorkspaceID: fmt.Sprintf("${tfe_workspace.workspace[%q].id}", ta.WorkspaceName),
 		Access:      ta.Access,
 		Permissions: ta.Permissions,
@@ -254,15 +254,17 @@ func (ws *WorkspaceConfig) AddTeamAccess(teamAccess []TeamAccess, organization s
 
 	for _, ta := range teamAccess {
 
-		_, ok := ws.Data["tfe_team"][ta.TeamName]
+		resourceName := ta.GetResourceName()
+
+		_, ok := ws.Data["tfe_team"][resourceName]
 		if !ok {
-			ws.Data["tfe_team"][ta.TeamName] = TeamDataResource{
+			ws.Data["tfe_team"][resourceName] = TeamDataResource{
 				Name:         ta.TeamName,
 				Organization: organization,
 			}
 		}
 
-		ws.Resources["tfe_team_access"][fmt.Sprintf("%s-%s", ta.WorkspaceName, ta.TeamName)] = NewWorkspaceTeamAccessResource(&ta)
+		ws.Resources["tfe_team_access"][fmt.Sprintf("%s-%s", ta.WorkspaceName, resourceName)] = NewWorkspaceTeamAccessResource(&ta)
 	}
 }
 

--- a/workspace_test.go
+++ b/workspace_test.go
@@ -621,6 +621,17 @@ func TestNewWorkspaceConfig(t *testing.T) {
 					Type: "set(string)",
 				},
 			},
+			RemoteStates: map[string]RemoteState{
+				"tfe": {
+					Backend: "remote",
+					Config: RemoteStateBackendConfig{
+						Organization: "org",
+						Workspaces: &RemoteStateBackendConfigWorkspaces{
+							Name: "tfe",
+						},
+					},
+				},
+			},
 			TeamAccess: []TeamAccess{
 				{TeamName: "Readers", WorkspaceName: name, Access: "read"},
 				{TeamName: "Writers", WorkspaceName: name, Permissions: &TeamAccessPermissions{
@@ -630,6 +641,12 @@ func TestNewWorkspaceConfig(t *testing.T) {
 					SentinelMocks:    "none",
 					WorkspaceLocking: true,
 				}},
+				{
+					ResourceName:  "engineering_department",
+					TeamName:      "${data.terraform_remote_state.tfe.outputs[\"Engineering (Department)\"].name}",
+					WorkspaceName: name,
+					Access:        "read",
+				},
 			},
 		})
 		if err != nil {


### PR DESCRIPTION
Ran into an interesting edge case using remote state references. 

When passing a team name as a remote state ref, terraform rightfully fails to validate. I was using TeamName as the resource name which is fine when the team name is Readers, but does not work when its `${data.terraform_remote_state.remote.outputs.team_name}`.

The simple solution here takes a ResourceName override which isn't great for two reasons
1) it exposes some the Terraform implementation under the hood
2) it's just another thing to remember to do when using remote references

I think a better approach which would be more work, would be to use the tfe.Client to do the get-team-by-name request instead of using data references within the plan.

FWIW, this issue does not apply to variables because we aren't using data blocks to lookup the resource there