### PR TITLE
Add verbose flag for printing out the workspace config

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ jobs:
 | `team_access` | YAML encoded teams and their associated permissions to be granted to the created workspaces | `false` |
 | `terraform_version` | Terraform version | `1.0.3` |
 | `terraform_host` | Terraform Cloud host | `app.terraform.io` |
-| `variables` | YAML encoded variables to apply to all workspaces | `""`
+| `variables` | YAML encoded variables to apply to all workspaces | `""` |
+| `verbose` | Log additional run information | `false` |
 | `vcs_ingress_submodules` | Whether to allow submodule ingress | `false` |
 | `vcs_repo` | Repository identifier for a VCS integration. Required if `vcs_name` or `vcs_token_id` are passed | `"${{ github.repository }}"` |
 | `vcs_token_id` | Terraform VCS client token ID. Takes precedence over `vcs_name`. If neither are passed, no VCS integration is added. | |

--- a/action.yml
+++ b/action.yml
@@ -75,6 +75,9 @@ inputs:
   team_access:
     description: YAML encoded teams and their associated permissions to be granted to the created workspaces
     required: false
+  verbose:
+    description: Log additional run information
+    default: false
 outputs:
   plan:
     description: Human readable Terraform plan

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ func main() {
 	host := githubactions.GetInput("terraform_host")
 	name := strings.TrimSpace(githubactions.GetInput("name"))
 	org := githubactions.GetInput("terraform_organization")
+	verbose := inputs.GetBool(githubactions.GetInput("verbose"))
 
 	client, err := tfe.NewClient(&tfe.Config{
 		Address: fmt.Sprintf("https://%s", host),
@@ -148,6 +149,10 @@ func main() {
 	b, err = json.MarshalIndent(wsConfig, "", "\t")
 	if err != nil {
 		log.Fatalf("Failed to marshal workspace configuration: %s", err)
+	}
+
+	if verbose {
+		fmt.Println(string(b))
 	}
 
 	workDir, err := ioutil.TempDir("", name)


### PR DESCRIPTION
Adds a verbose option that as of right now, prints out the workspace config. This is pretty useful for debugging invalid config errors and github appears to be good about redacting secrets in the log output. 

<details><summary>Example</summary>
<pre>
{
	"terraform": {
		"backend": {
			"s3": {
				"bucket": "***",
				"key": "terraform-provider-configuration.tfstate",
				"region": "***",
				"access_key": "***",
				"secret_key": "***",
				"role_arn": "***"
			}
		}
	},
	"variable": {
		"workspace_names": {
			"type": "set(string)"
		}
	},
	"resource": {
		"tfe_team_access": {
			"terraform-provider-configuration-${data.terraform_remote_state.tfe.outputs[\"Engineering (Department)\"].name}": {
				"team_id": "${data.tfe_team.${data.terraform_remote_state.tfe.outputs[\"Engineering (Department)\"].name}.id}",
				"workspace_id": "${tfe_workspace.workspace[\"terraform-provider-configuration\"].id}",
				"access": "read"
			},
			"terraform-provider-configuration-${data.terraform_remote_state.tfe.outputs[\"Platform\"].name}": {
				"team_id": "${data.tfe_team.${data.terraform_remote_state.tfe.outputs[\"Platform\"].name}.id}",
				"workspace_id": "${tfe_workspace.workspace[\"terraform-provider-configuration\"].id}",
				"access": "write"
			}
		},
		"tfe_workspace": {
			"workspace": {
				"for_each": "${var.workspace_names}",
				"auto_apply": true,
				"global_remote_state": false,
				"name": "${each.value}",
				"organization": "takescoop",
				"terraform_version": "0.14.11",
				"vcs_repo": {
					"oauth_token_id": "ot-mjYYQ1U3rNCTxPgT",
					"identifier": "takescoop/mars",
					"ingress_submodules": false
				}
			}
		}
	},
	"data": {
		"terraform_remote_state": {
			"tfe": {
				"config": {
					"hostname": "terraform.takescoop.com",
					"organization": "takescoop",
					"workspaces": {
						"name": "terraform-enterprise"
					}
				},
				"backend": "remote"
			}
		},
		"tfe_team": {
			"${data.terraform_remote_state.tfe.outputs[\"Engineering (Department)\"].name}": {
				"name": "${data.terraform_remote_state.tfe.outputs[\"Engineering (Department)\"].name}",
				"organization": "takescoop"
			},
			"${data.terraform_remote_state.tfe.outputs[\"Platform\"].name}": {
				"name": "${data.terraform_remote_state.tfe.outputs[\"Platform\"].name}",
				"organization": "takescoop"
			}
		}
	}
}
</pre>
</details>