### PR TITLE
Add providers block

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ jobs:
 | `team_access` | YAML encoded teams and their associated permissions to be granted to the created workspaces | `false` |
 | `terraform_version` | Terraform version | `1.0.3` |
 | `terraform_host` | Terraform Cloud host | `app.terraform.io` |
-| `tfe_provider_version` | Terraform Cloud provider version | `"~> 0.25.0"` |
+| `tfe_provider_version` | Terraform Cloud provider version | `0.25.3` |
 | `variables` | YAML encoded variables to apply to all workspaces | `""`
 | `vcs_ingress_submodules` | Whether to allow submodule ingress | `false` |
 | `vcs_repo` | Repository identifier for a VCS integration. Required if `vcs_name` or `vcs_token_id` are passed | `"${{ github.repository }}"` |

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ jobs:
 | `team_access` | YAML encoded teams and their associated permissions to be granted to the created workspaces | `false` |
 | `terraform_version` | Terraform version | `1.0.3` |
 | `terraform_host` | Terraform Cloud host | `app.terraform.io` |
+| `tfe_provider_version` | Terraform Cloud provider version | `"~> 0.25.0"` |
 | `variables` | YAML encoded variables to apply to all workspaces | `""`
 | `vcs_ingress_submodules` | Whether to allow submodule ingress | `false` |
 | `vcs_repo` | Repository identifier for a VCS integration. Required if `vcs_name` or `vcs_token_id` are passed | `"${{ github.repository }}"` |

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,9 @@ inputs:
   terraform_organization:
     description: Terraform Cloud organization
     required: true
+  tfe_provider_version:
+    description: Terraform Cloud provider version
+    default: ~> 0.25.0
   name:
     description: Name of the workspace. Becomes a prefix if workspaces are passed (`${name}-${workspace}`)
     default: "${{ github.event.repository.name }}"

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
     required: true
   tfe_provider_version:
     description: Terraform Cloud provider version
-    default: ~> 0.25.0
+    default: "0.25.3"
   name:
     description: Name of the workspace. Becomes a prefix if workspaces are passed (`${name}-${workspace}`)
     default: "${{ github.event.repository.name }}"

--- a/main.go
+++ b/main.go
@@ -140,6 +140,12 @@ func main() {
 		RemoteStates: remoteStates,
 		Variables:    vars,
 		TeamAccess:   teamAccess,
+		Providers: map[string]WorkspaceProvider{
+			"tfe": {
+				Version:  githubactions.GetInput("tfe_provider_version"),
+				Hostname: host,
+			},
+		},
 	})
 	if err != nil {
 		log.Fatalf("Failed to create new workspace configuration: %s", err)

--- a/main.go
+++ b/main.go
@@ -112,9 +112,7 @@ func main() {
 	}
 
 	wsConfig, err := NewWorkspaceConfig(ctx, client, &NewWorkspaceConfigOptions{
-		TerraformBackendConfig: &WorkspaceTerraform{
-			Backend: *wsBackend,
-		},
+		Backend: wsBackend,
 		WorkspaceResourceOptions: &WorkspaceResourceOptions{
 			AgentPoolID:            githubactions.GetInput("agent_pool_id"),
 			AutoApply:              inputs.GetBoolPtr("auto_apply"),
@@ -140,10 +138,14 @@ func main() {
 		RemoteStates: remoteStates,
 		Variables:    vars,
 		TeamAccess:   teamAccess,
-		Providers: map[string]WorkspaceProvider{
-			"tfe": {
-				Version:  githubactions.GetInput("tfe_provider_version"),
-				Hostname: host,
+		Providers: []Provider{
+			{
+				Name:    "tfe",
+				Version: githubactions.GetInput("tfe_provider_version"),
+				Source:  "hashicorp/tfe",
+				Config: TFEProvider{
+					Hostname: host,
+				},
 			},
 		},
 	})

--- a/providers.go
+++ b/providers.go
@@ -1,0 +1,15 @@
+package main
+
+type Provider struct {
+	Version string
+	Source  string
+	Name    string
+	Config  ProviderConfig
+}
+
+type ProviderConfig interface{}
+
+type TFEProvider struct {
+	Hostname string `json:"hostname"`
+	Token    string `json:"token,omitempty"`
+}

--- a/workspace.go
+++ b/workspace.go
@@ -13,6 +13,7 @@ type WorkspaceConfig struct {
 	Variables map[string]WorkspaceVariable      `json:"variable,omitempty"`
 	Resources map[string]map[string]interface{} `json:"resource,omitempty"`
 	Data      map[string]map[string]interface{} `json:"data,omitempty"`
+	Providers map[string]WorkspaceProvider      `json:"provider"`
 }
 
 type WorkspaceTerraform struct {
@@ -75,6 +76,12 @@ type WorkspaceVariableResource struct {
 	Category    string `json:"category,omitempty"`
 	WorkspaceID string `json:"workspace_id,omitempty"`
 	Sensitive   bool   `json:"sensitive,omitempty"`
+}
+
+type WorkspaceProvider struct {
+	Version  string `json:"version"`
+	Hostname string `json:"hostname"`
+	Token    string `json:"token,omitempty"`
 }
 
 // getVCSClientByName looks for a VCS client of the passed type against the VCS clients in the Terraform Cloud organization
@@ -286,6 +293,7 @@ type NewWorkspaceConfigOptions struct {
 	Variables                []Variable
 	TeamAccess               []TeamAccess
 	WorkspaceResourceOptions *WorkspaceResourceOptions
+	Providers                map[string]WorkspaceProvider
 }
 
 // NewWorkspaceConfig takes in all required values for the Terraform workspace and outputs a struct that can be marshalled then planned or applied
@@ -304,6 +312,7 @@ func NewWorkspaceConfig(ctx context.Context, client *tfe.Client, config *NewWork
 				"workspace": wsResource,
 			},
 		},
+		Providers: config.Providers,
 	}
 
 	wsConfig.AddRemoteStates(config.RemoteStates)


### PR DESCRIPTION
Adds provider configuration to terraform workspace which will allow an enterprise backend instead of the default app.terraform.io

Also removed a json string matching test that hurts more than it helps at this point. We have some nice json validation tests and test for specific values to exist on structs elsewhere, so this seems excessive.