### PR TITLE
Fix workspace variable lookup against incorrect workspace name

### DIFF
--- a/main.go
+++ b/main.go
@@ -71,13 +71,25 @@ func main() {
 		log.Fatalf("Failed to parse remote state blocks%s", err)
 	}
 
-	var workspaces []string
+	var workspaces []*Workspace
 
 	if githubactions.GetInput("workspaces") == "" {
-		workspaces = append(workspaces, name)
+		workspaces = append(workspaces, &Workspace{
+			Name:      name,
+			Workspace: "default",
+		})
 	} else {
-		if err = yaml.Unmarshal([]byte(githubactions.GetInput("workspaces")), workspaces); err != nil {
+		var wsNames []string
+
+		if err = yaml.Unmarshal([]byte(githubactions.GetInput("workspaces")), wsNames); err != nil {
 			log.Fatalf("Failed to parse workspaces: %s", err)
+		}
+
+		for _, wsn := range wsNames {
+			workspaces = append(workspaces, &Workspace{
+				Name:      fmt.Sprintf("%s-%s", name, wsn),
+				Workspace: wsn,
+			})
 		}
 	}
 
@@ -168,7 +180,12 @@ func main() {
 		log.Fatalf("error running Init: %s", err)
 	}
 
-	wsBytes, err := json.Marshal(workspaces)
+	wsNames := make([]string, len(workspaces))
+	for i, ws := range workspaces {
+		wsNames[i] = ws.Name
+	}
+
+	wsBytes, err := json.Marshal(wsNames)
 	if err != nil {
 		log.Fatalf("error marshalling workspaces input: %s", err)
 	}
@@ -185,8 +202,8 @@ func main() {
 			opts[i] = v
 		}
 
-		for _, name := range workspaces {
-			err = ImportWorkspace(ctx, tf, client, name, org, opts...)
+		for _, ws := range workspaces {
+			err = ImportWorkspace(ctx, tf, client, ws.Name, org, opts...)
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/team_access.go
+++ b/team_access.go
@@ -16,13 +16,13 @@ type TeamAccessPermissions struct {
 }
 
 // MergeWorkspaceIDs returns a new slice of TeamAccess structs
-func MergeWorkspaceIDs(teamAccess []TeamAccess, workspaceNames []string) []TeamAccess {
-	ts := make([]TeamAccess, len(teamAccess)*len(workspaceNames))
+func MergeWorkspaceIDs(teamAccess []TeamAccess, workspaces []*Workspace) []TeamAccess {
+	ts := make([]TeamAccess, len(teamAccess)*len(workspaces))
 
 	i := 0
 	for _, team := range teamAccess {
-		for _, name := range workspaceNames {
-			team.WorkspaceName = name
+		for _, ws := range workspaces {
+			team.WorkspaceName = ws.Name
 			ts[i] = team
 			i = i + 1
 		}

--- a/team_access_test.go
+++ b/team_access_test.go
@@ -13,13 +13,16 @@ func TestMergeWorkspaceIDs(t *testing.T) {
 				{Access: "read", TeamName: "readers"},
 				{Access: "write", TeamName: "writers"},
 			},
-			[]string{"staging", "production"},
+			[]*Workspace{
+				{Name: "api-staging", Workspace: "staging"},
+				{Name: "api-production", Workspace: "staging"},
+			},
 		),
 		[]TeamAccess{
-			{Access: "read", TeamName: "readers", WorkspaceName: "staging"},
-			{Access: "read", TeamName: "readers", WorkspaceName: "production"},
-			{Access: "write", TeamName: "writers", WorkspaceName: "staging"},
-			{Access: "write", TeamName: "writers", WorkspaceName: "production"},
+			{Access: "read", TeamName: "readers", WorkspaceName: "api-staging"},
+			{Access: "read", TeamName: "readers", WorkspaceName: "api-production"},
+			{Access: "write", TeamName: "writers", WorkspaceName: "api-staging"},
+			{Access: "write", TeamName: "writers", WorkspaceName: "api-production"},
 		},
 	)
 }

--- a/variables.go
+++ b/variables.go
@@ -13,15 +13,6 @@ type Variable struct {
 	WorkspaceName string
 }
 
-func contains(strings []string, target string) bool {
-	for _, v := range strings {
-		if v == target {
-			return true
-		}
-	}
-	return false
-}
-
 func findWorkspace(workspaces []*Workspace, target string) *Workspace {
 	for _, v := range workspaces {
 		if v.Workspace == target {

--- a/variables.go
+++ b/variables.go
@@ -22,26 +22,41 @@ func contains(strings []string, target string) bool {
 	return false
 }
 
+func findWorkspace(workspaces []*Workspace, target string) *Workspace {
+	for _, v := range workspaces {
+		if v.Workspace == target {
+			return v
+		}
+	}
+	return nil
+}
+
 // ParseVariablesByWorkspace takes a list of workspace names, general variables and workspaced variables and flattens them into a single set
-func ParseVariablesByWorkspace(names []string, generalVars *[]Variable, workspaceVars *map[string][]Variable) ([]Variable, error) {
+func ParseVariablesByWorkspace(workspaces []*Workspace, generalVars *[]Variable, workspaceVars *map[string][]Variable) ([]Variable, error) {
 	vars := []Variable{}
 	for _, v := range *generalVars {
-		for _, ws := range names {
+		for _, ws := range workspaces {
 			newVar := v
 
-			newVar.WorkspaceName = ws
+			newVar.WorkspaceName = ws.Name
 
 			vars = append(vars, newVar)
 		}
 	}
 
-	for ws, vs := range *workspaceVars {
-		if !contains(names, ws) {
-			return nil, fmt.Errorf("workspace %q was not found in planned workspaces %v", ws, names)
+	workspacesNames := make([]string, len(workspaces))
+	for i, ws := range workspaces {
+		workspacesNames[i] = ws.Workspace
+	}
+
+	for wsName, vs := range *workspaceVars {
+		w := findWorkspace(workspaces, wsName)
+		if w == nil {
+			return nil, fmt.Errorf("workspace %q was not found in planned workspaces %v", wsName, workspacesNames)
 		}
 
 		for _, v := range vs {
-			v.WorkspaceName = ws
+			v.WorkspaceName = w.Name
 
 			vars = append(vars, v)
 		}

--- a/workspace.go
+++ b/workspace.go
@@ -8,6 +8,11 @@ import (
 	tfe "github.com/hashicorp/go-tfe"
 )
 
+type Workspace struct {
+	Name      string
+	Workspace string
+}
+
 type WorkspaceConfig struct {
 	Terraform WorkspaceTerraform                `json:"terraform"`
 	Variables map[string]WorkspaceVariable      `json:"variable,omitempty"`


### PR DESCRIPTION
I noticed during the demo today, that the way the docs outline workspaced variables will not work.

This is how we want the interface to be
```yml
workspace_variables: |-
  staging: ...
  production: ...
```

This is how the interface actually works at the moment
```yml
name: foo
workspace_variables: |-
  foo-staging: ...
  foo-production: ...
```

To fix this, I've introduced a coupled type Workspace with Name and Workspace properties. The Name is the full name, Workspace is the workspace name that terraform would expect to use when transitioning between workspaces. Workspace is a very overloaded term in this project, so if you have any naming suggestions here lmk.

Variables are looked up against the workspace name, but assigned the full name for matching against the workspace resource. Team access is the only other resource that uses workspace refs and they apply to the same across the board so, no change there.