### PR TITLE
Error on workspace deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ jobs:
 
 | Name | Description | Default |
 | --- | --- | --- |
+| `allow_workspace_deletion` | Whether to allow the lan run to proceed if the a workspace is planned for deletion | `false` |
 | `apply` | (required) Whether to apply the proposed Terraform changes | |
 | `terraform_organization` | (required) Terraform Cloud organization | |
 | `terraform_token`  | (required) Terraform Cloud token | |

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ jobs:
 
 | Name | Description | Default |
 | --- | --- | --- |
-| `allow_workspace_deletion` | Whether to allow the lan run to proceed if the a workspace is planned for deletion | `false` |
+| `allow_workspace_deletion` | Whether to allow workspaces to be deleted. If enabled, workspace state may be irrecoverably deleted. | `false` |
 | `apply` | (required) Whether to apply the proposed Terraform changes | |
 | `terraform_organization` | (required) Terraform Cloud organization | |
 | `terraform_token`  | (required) Terraform Cloud token | |

--- a/action.yml
+++ b/action.yml
@@ -78,6 +78,9 @@ inputs:
   team_access:
     description: YAML encoded teams and their associated permissions to be granted to the created workspaces
     required: false
+  allow_workspace_deletion:
+    description: Whether to allow deletion for the workspace resources
+    default: false
 outputs:
   plan:
     description: Human readable Terraform plan

--- a/main.go
+++ b/main.go
@@ -267,6 +267,10 @@ func main() {
 
 		githubactions.SetOutput("plan_json", string(b))
 
+		if !inputs.GetBool("allow_workspace_deletion") && PlanForDeletion(plan, "tfe_workspace") {
+			log.Fatal("Error: Workspace planned for deletion. If this is indented, set allow_workspace_deletion to true to proceed.")
+		}
+
 		if inputs.GetBool("apply") {
 			fmt.Println("Applying...")
 

--- a/main.go
+++ b/main.go
@@ -267,8 +267,8 @@ func main() {
 
 		githubactions.SetOutput("plan_json", string(b))
 
-		if !inputs.GetBool("allow_workspace_deletion") && PlanForDeletion(plan, "tfe_workspace") {
-			log.Fatal("Error: Workspace planned for deletion. If this is intententional, set allow_workspace_deletion to true to proceed.")
+		if !inputs.GetBool("allow_workspace_deletion") && WillDestroy(plan, "tfe_workspace") {
+			log.Fatal("Error: Workspace planned for deletion. If this is intentional, set allow_workspace_deletion to true to proceed.")
 		}
 
 		if inputs.GetBool("apply") {

--- a/main.go
+++ b/main.go
@@ -268,7 +268,7 @@ func main() {
 		githubactions.SetOutput("plan_json", string(b))
 
 		if !inputs.GetBool("allow_workspace_deletion") && PlanForDeletion(plan, "tfe_workspace") {
-			log.Fatal("Error: Workspace planned for deletion. If this is indented, set allow_workspace_deletion to true to proceed.")
+			log.Fatal("Error: Workspace planned for deletion. If this is intententional, set allow_workspace_deletion to true to proceed.")
 		}
 
 		if inputs.GetBool("apply") {

--- a/terraform.go
+++ b/terraform.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-exec/tfexec"
+	"github.com/hashicorp/terraform-exec/tfinstall"
+)
+
+func NewTerraformExec(ctx context.Context, workDir string, version string) (*tfexec.Terraform, error) {
+	execPath, err := tfinstall.Find(
+		ctx,
+		tfinstall.ExactVersion(version, workDir),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return tfexec.NewTerraform(workDir, execPath)
+}

--- a/workspace.go
+++ b/workspace.go
@@ -351,7 +351,7 @@ func (ws *WorkspaceConfig) AddProviders(providers []Provider) {
 	ws.Terraform.RequiredProviders = versions
 }
 
-// PlanWorkspaceDeletion takes a Terraform plan and looks for whether the delete action is associated with any tfe_workspace resource
+// PlanWorkspaceDeletion parses a plan to look for whether the delete action is associated with any target resource
 func PlanForDeletion(plan *tfjson.Plan, targetType string) bool {
 	for _, res := range plan.ResourceChanges {
 		if res.Type == targetType {

--- a/workspace.go
+++ b/workspace.go
@@ -354,9 +354,9 @@ func (ws *WorkspaceConfig) AddProviders(providers []Provider) {
 // PlanWorkspaceDeletion parses a plan to look for whether the delete action is associated with any target resource
 func PlanForDeletion(plan *tfjson.Plan, targetType string) bool {
 	for _, rc := range plan.ResourceChanges {
-		if res.Type == targetType {
-			for _, action := range res.Change.Actions {
-				if change == tfjson.ActionDelete {
+		if rc.Type == targetType {
+			for _, action := range rc.Change.Actions {
+				if action == tfjson.ActionDelete {
 					return true
 				}
 			}

--- a/workspace.go
+++ b/workspace.go
@@ -351,8 +351,8 @@ func (ws *WorkspaceConfig) AddProviders(providers []Provider) {
 	ws.Terraform.RequiredProviders = versions
 }
 
-// PlanWorkspaceDeletion parses a plan to look for whether the delete action is associated with any target resource
-func PlanForDeletion(plan *tfjson.Plan, targetType string) bool {
+// WillDestroy parses a plan to look for whether the delete action is associated with any target resource
+func WillDestroy(plan *tfjson.Plan, targetType string) bool {
 	for _, rc := range plan.ResourceChanges {
 		if rc.Type == targetType {
 			for _, action := range rc.Change.Actions {

--- a/workspace.go
+++ b/workspace.go
@@ -353,9 +353,9 @@ func (ws *WorkspaceConfig) AddProviders(providers []Provider) {
 
 // PlanWorkspaceDeletion parses a plan to look for whether the delete action is associated with any target resource
 func PlanForDeletion(plan *tfjson.Plan, targetType string) bool {
-	for _, res := range plan.ResourceChanges {
+	for _, rc := range plan.ResourceChanges {
 		if res.Type == targetType {
-			for _, change := range res.Change.Actions {
+			for _, action := range res.Change.Actions {
 				if change == tfjson.ActionDelete {
 					return true
 				}

--- a/workspace.go
+++ b/workspace.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	tfe "github.com/hashicorp/go-tfe"
+	tfjson "github.com/hashicorp/terraform-json"
 )
 
 type Workspace struct {
@@ -348,4 +349,19 @@ func (ws *WorkspaceConfig) AddProviders(providers []Provider) {
 
 	ws.Providers = providerConfigs
 	ws.Terraform.RequiredProviders = versions
+}
+
+// PlanWorkspaceDeletion takes a Terraform plan and looks for whether the delete action is associated with any tfe_workspace resource
+func PlanForDeletion(plan *tfjson.Plan, targetType string) bool {
+	for _, res := range plan.ResourceChanges {
+		if res.Type == targetType {
+			for _, change := range res.Change.Actions {
+				if change == tfjson.ActionDelete {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
 }

--- a/workspace_test.go
+++ b/workspace_test.go
@@ -624,60 +624,115 @@ func TestNewWorkspaceConfig(t *testing.T) {
 }
 
 func TestWillDestroy(t *testing.T) {
-	t.Run("return true when a resource is scheduled for deletion", func(t *testing.T) {
-		ctx := context.Background()
+	// 	t.Run("return true when a resource is scheduled for deletion", func(t *testing.T) {
+	// 		ctx := context.Background()
 
-		workDir, err := ioutil.TempDir("", "deletion")
-		if err != nil {
-			t.Fatal(err)
-		}
+	// 		workDir, err := ioutil.TempDir("", "deletion")
+	// 		if err != nil {
+	// 			t.Fatal(err)
+	// 		}
 
-		defer os.RemoveAll(workDir)
+	// 		defer os.RemoveAll(workDir)
 
-		tf, err := NewTerraformExec(ctx, workDir, "1.0.3")
-		if err != nil {
-			t.Fatal(err)
-		}
+	// 		tf, err := NewTerraformExec(ctx, workDir, "1.0.3")
+	// 		if err != nil {
+	// 			t.Fatal(err)
+	// 		}
 
-		b := []byte(`
-resource "random_pet" "first" {}
-resource "random_pet" "second" {}
-`)
+	// 		b := []byte(`
+	// resource "random_pet" "first" {}
+	// resource "random_pet" "second" {}
+	// `)
 
-		if err = ioutil.WriteFile(path.Join(workDir, "main.tf"), b, 0644); err != nil {
-			t.Fatal(err)
-		}
+	// 		if err = ioutil.WriteFile(path.Join(workDir, "main.tf"), b, 0644); err != nil {
+	// 			t.Fatal(err)
+	// 		}
 
-		if err = tf.Init(ctx); err != nil {
-			t.Fatal(err)
-		}
+	// 		if err = tf.Init(ctx); err != nil {
+	// 			t.Fatal(err)
+	// 		}
 
-		if err = tf.Apply(ctx); err != nil {
-			t.Fatal()
-		}
+	// 		if err = tf.Apply(ctx); err != nil {
+	// 			t.Fatal(err)
+	// 		}
 
-		b = []byte(`
-resource "random_pet" "first" {}
-`)
-		if err = ioutil.WriteFile(path.Join(workDir, "main.tf"), b, 0644); err != nil {
-			t.Fatal(err)
-		}
+	// 		b = []byte(`
+	// resource "random_pet" "first" {}
+	// `)
+	// 		if err = ioutil.WriteFile(path.Join(workDir, "main.tf"), b, 0644); err != nil {
+	// 			t.Fatal(err)
+	// 		}
 
-		planPath := "plan.txt"
+	// 		planPath := "plan.txt"
 
-		if _, err = tf.Plan(ctx, tfexec.Out(planPath)); err != nil {
-			t.Fatal(err)
-		}
+	// 		if _, err = tf.Plan(ctx, tfexec.Out(planPath)); err != nil {
+	// 			t.Fatal(err)
+	// 		}
 
-		plan, err := tf.ShowPlanFile(ctx, planPath)
-		if err != nil {
-			t.Fatal(err)
-		}
+	// 		plan, err := tf.ShowPlanFile(ctx, planPath)
+	// 		if err != nil {
+	// 			t.Fatal(err)
+	// 		}
 
-		assert.Equal(t, WillDestroy(plan, "random_pet"), true)
-	})
+	// 		assert.Equal(t, WillDestroy(plan, "random_pet"), true)
+	// 	})
 
-	t.Run("return false when a resource is not scheduled for deletion", func(t *testing.T) {
+	// 	t.Run("return false when a resource is not scheduled for deletion", func(t *testing.T) {
+	// 		ctx := context.Background()
+
+	// 		workDir, err := ioutil.TempDir("", "no-deletion")
+	// 		if err != nil {
+	// 			t.Fatal(err)
+	// 		}
+
+	// 		defer os.RemoveAll(workDir)
+
+	// 		tf, err := NewTerraformExec(ctx, workDir, "1.0.3")
+	// 		if err != nil {
+	// 			t.Fatal(err)
+	// 		}
+
+	// 		b := []byte(`
+	// resource "random_pet" "first" {}
+	// resource "random_pet" "second" {}
+	// `)
+
+	// 		if err = ioutil.WriteFile(path.Join(workDir, "main.tf"), b, 0644); err != nil {
+	// 			t.Fatal(err)
+	// 		}
+
+	// 		if err = tf.Init(ctx); err != nil {
+	// 			t.Fatal(err)
+	// 		}
+
+	// 		if err = tf.Apply(ctx); err != nil {
+	// 			t.Fatal(err)
+	// 		}
+
+	// 		b = []byte(`
+	// resource "random_pet" "first" {}
+	// resource "random_pet" "second" {}
+	// resource "random_pet" "third" {}
+	// `)
+	// 		if err = ioutil.WriteFile(path.Join(workDir, "main.tf"), b, 0644); err != nil {
+	// 			t.Fatal(err)
+	// 		}
+
+	// 		planPath := "plan.txt"
+
+	// 		if _, err = tf.Plan(ctx, tfexec.Out(planPath)); err != nil {
+	// 			t.Fatal(err)
+	// 		}
+
+	// 		plan, err := tf.ShowPlanFile(ctx, planPath)
+	// 		if err != nil {
+	// 			t.Fatal(err)
+	// 		}
+
+	// 		assert.Equal(t, WillDestroy(plan, "random_pet"), false)
+	// 	})
+
+	t.Run("return false when a non targetted resource is scheduled for deletion", func(t *testing.T) {
 		ctx := context.Background()
 
 		workDir, err := ioutil.TempDir("", "no-deletion")
@@ -693,8 +748,10 @@ resource "random_pet" "first" {}
 		}
 
 		b := []byte(`
-resource "random_pet" "first" {}
-resource "random_pet" "second" {}
+resource "random_pet" "pet" {}
+resource "random_id" "id" {
+	byte_length = 8
+}
 `)
 
 		if err = ioutil.WriteFile(path.Join(workDir, "main.tf"), b, 0644); err != nil {
@@ -706,13 +763,11 @@ resource "random_pet" "second" {}
 		}
 
 		if err = tf.Apply(ctx); err != nil {
-			t.Fatal()
+			t.Fatal(err)
 		}
 
 		b = []byte(`
-resource "random_pet" "first" {}
-resource "random_pet" "second" {}
-resource "random_pet" "third" {}
+resource "random_pet" "pet" {}
 `)
 		if err = ioutil.WriteFile(path.Join(workDir, "main.tf"), b, 0644); err != nil {
 			t.Fatal(err)

--- a/workspace_test.go
+++ b/workspace_test.go
@@ -659,16 +659,16 @@ func planWithWorkspaceAction(actions tfjson.Actions) *tfjson.Plan {
 	}
 }
 
-func TestPlanWorkspaceDeletion(t *testing.T) {
+func TestWillDestroy(t *testing.T) {
 	t.Run("return false when a tfe_workspace not set for deletion", func(t *testing.T) {
 		plan := planWithWorkspaceAction(tfjson.Actions{tfjson.ActionCreate})
 
-		assert.Equal(t, PlanForDeletion(plan, "tfe_workspace"), false)
+		assert.Equal(t, WillDestroy(plan, "tfe_workspace"), false)
 	})
 
 	t.Run("return true when a tfe_workspace is set to be deleted", func(t *testing.T) {
 		plan := planWithWorkspaceAction(tfjson.Actions{tfjson.ActionDelete})
 
-		assert.Equal(t, PlanForDeletion(plan, "tfe_workspace"), true)
+		assert.Equal(t, WillDestroy(plan, "tfe_workspace"), true)
 	})
 }

--- a/workspace_test.go
+++ b/workspace_test.go
@@ -624,113 +624,113 @@ func TestNewWorkspaceConfig(t *testing.T) {
 }
 
 func TestWillDestroy(t *testing.T) {
-	// 	t.Run("return true when a resource is scheduled for deletion", func(t *testing.T) {
-	// 		ctx := context.Background()
+	t.Run("return true when a resource is scheduled for deletion", func(t *testing.T) {
+		ctx := context.Background()
 
-	// 		workDir, err := ioutil.TempDir("", "deletion")
-	// 		if err != nil {
-	// 			t.Fatal(err)
-	// 		}
+		workDir, err := ioutil.TempDir("", "deletion")
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	// 		defer os.RemoveAll(workDir)
+		defer os.RemoveAll(workDir)
 
-	// 		tf, err := NewTerraformExec(ctx, workDir, "1.0.3")
-	// 		if err != nil {
-	// 			t.Fatal(err)
-	// 		}
+		tf, err := NewTerraformExec(ctx, workDir, "1.0.3")
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	// 		b := []byte(`
-	// resource "random_pet" "first" {}
-	// resource "random_pet" "second" {}
-	// `)
+		b := []byte(`
+	resource "random_pet" "first" {}
+	resource "random_pet" "second" {}
+	`)
 
-	// 		if err = ioutil.WriteFile(path.Join(workDir, "main.tf"), b, 0644); err != nil {
-	// 			t.Fatal(err)
-	// 		}
+		if err = ioutil.WriteFile(path.Join(workDir, "main.tf"), b, 0644); err != nil {
+			t.Fatal(err)
+		}
 
-	// 		if err = tf.Init(ctx); err != nil {
-	// 			t.Fatal(err)
-	// 		}
+		if err = tf.Init(ctx); err != nil {
+			t.Fatal(err)
+		}
 
-	// 		if err = tf.Apply(ctx); err != nil {
-	// 			t.Fatal(err)
-	// 		}
+		if err = tf.Apply(ctx); err != nil {
+			t.Fatal(err)
+		}
 
-	// 		b = []byte(`
-	// resource "random_pet" "first" {}
-	// `)
-	// 		if err = ioutil.WriteFile(path.Join(workDir, "main.tf"), b, 0644); err != nil {
-	// 			t.Fatal(err)
-	// 		}
+		b = []byte(`
+	resource "random_pet" "first" {}
+	`)
+		if err = ioutil.WriteFile(path.Join(workDir, "main.tf"), b, 0644); err != nil {
+			t.Fatal(err)
+		}
 
-	// 		planPath := "plan.txt"
+		planPath := "plan.txt"
 
-	// 		if _, err = tf.Plan(ctx, tfexec.Out(planPath)); err != nil {
-	// 			t.Fatal(err)
-	// 		}
+		if _, err = tf.Plan(ctx, tfexec.Out(planPath)); err != nil {
+			t.Fatal(err)
+		}
 
-	// 		plan, err := tf.ShowPlanFile(ctx, planPath)
-	// 		if err != nil {
-	// 			t.Fatal(err)
-	// 		}
+		plan, err := tf.ShowPlanFile(ctx, planPath)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	// 		assert.Equal(t, WillDestroy(plan, "random_pet"), true)
-	// 	})
+		assert.Equal(t, WillDestroy(plan, "random_pet"), true)
+	})
 
-	// 	t.Run("return false when a resource is not scheduled for deletion", func(t *testing.T) {
-	// 		ctx := context.Background()
+	t.Run("return false when a resource is not scheduled for deletion", func(t *testing.T) {
+		ctx := context.Background()
 
-	// 		workDir, err := ioutil.TempDir("", "no-deletion")
-	// 		if err != nil {
-	// 			t.Fatal(err)
-	// 		}
+		workDir, err := ioutil.TempDir("", "no-deletion")
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	// 		defer os.RemoveAll(workDir)
+		defer os.RemoveAll(workDir)
 
-	// 		tf, err := NewTerraformExec(ctx, workDir, "1.0.3")
-	// 		if err != nil {
-	// 			t.Fatal(err)
-	// 		}
+		tf, err := NewTerraformExec(ctx, workDir, "1.0.3")
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	// 		b := []byte(`
-	// resource "random_pet" "first" {}
-	// resource "random_pet" "second" {}
-	// `)
+		b := []byte(`
+	resource "random_pet" "first" {}
+	resource "random_pet" "second" {}
+	`)
 
-	// 		if err = ioutil.WriteFile(path.Join(workDir, "main.tf"), b, 0644); err != nil {
-	// 			t.Fatal(err)
-	// 		}
+		if err = ioutil.WriteFile(path.Join(workDir, "main.tf"), b, 0644); err != nil {
+			t.Fatal(err)
+		}
 
-	// 		if err = tf.Init(ctx); err != nil {
-	// 			t.Fatal(err)
-	// 		}
+		if err = tf.Init(ctx); err != nil {
+			t.Fatal(err)
+		}
 
-	// 		if err = tf.Apply(ctx); err != nil {
-	// 			t.Fatal(err)
-	// 		}
+		if err = tf.Apply(ctx); err != nil {
+			t.Fatal(err)
+		}
 
-	// 		b = []byte(`
-	// resource "random_pet" "first" {}
-	// resource "random_pet" "second" {}
-	// resource "random_pet" "third" {}
-	// `)
-	// 		if err = ioutil.WriteFile(path.Join(workDir, "main.tf"), b, 0644); err != nil {
-	// 			t.Fatal(err)
-	// 		}
+		b = []byte(`
+	resource "random_pet" "first" {}
+	resource "random_pet" "second" {}
+	resource "random_pet" "third" {}
+	`)
+		if err = ioutil.WriteFile(path.Join(workDir, "main.tf"), b, 0644); err != nil {
+			t.Fatal(err)
+		}
 
-	// 		planPath := "plan.txt"
+		planPath := "plan.txt"
 
-	// 		if _, err = tf.Plan(ctx, tfexec.Out(planPath)); err != nil {
-	// 			t.Fatal(err)
-	// 		}
+		if _, err = tf.Plan(ctx, tfexec.Out(planPath)); err != nil {
+			t.Fatal(err)
+		}
 
-	// 		plan, err := tf.ShowPlanFile(ctx, planPath)
-	// 		if err != nil {
-	// 			t.Fatal(err)
-	// 		}
+		plan, err := tf.ShowPlanFile(ctx, planPath)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	// 		assert.Equal(t, WillDestroy(plan, "random_pet"), false)
-	// 	})
+		assert.Equal(t, WillDestroy(plan, "random_pet"), false)
+	})
 
 	t.Run("return false when a non targetted resource is scheduled for deletion", func(t *testing.T) {
 		ctx := context.Background()


### PR DESCRIPTION
After a plan is created, if `allow_workspace_deletion` is false and the plan contains a `tfe_workspace` delete action, exit non zero and report the deletion to the user with a hint to change `allow_workspace_deletion` to true if this is the intended behavior.

I opted to put this in the "planning" phase of the action over the "applying" phase because at apply time, it's likely the user will have committed the code already so they'll need to submit an updated PR to resolve the issue.