### PR TITLE
Pass token to tfe provider

### DIFF
--- a/main.go
+++ b/main.go
@@ -157,6 +157,7 @@ func main() {
 				Source:  "hashicorp/tfe",
 				Config: TFEProvider{
 					Hostname: host,
+					Token:    token,
 				},
 			},
 		},


### PR DESCRIPTION
I had hoped that setting the credentials block in the home directory would be sufficient for the tfe provider, but this does not seem to be the case. 

Seems that the credentials block might only be used to run plans against tf cloud backends, so that block might not really be doing anything.

<details><summary>Error example</summary>
<pre>
Error: Invalid provider configuration

Provider "registry.terraform.io/hashicorp/tfe" requires explicit
configuration. Add a provider block to the root module and configure the
provider's required arguments as described in the provider documentation.


Error: Required token could not be found. Please set the token using an input variable in the provider configuration block or by using the TFE_TOKEN environment variable.

  with provider["registry.terraform.io/hashicorp/tfe"],
  on <empty> line 0:
  (source code not available)
</pre>
</details>

[ref](https://github.com/TakeScoop/terraform-provider-configuration/runs/3295306119?check_suite_focus=true)