### PR TITLE
Add tf validation to proposed workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ jobs:
 | `remote_states` | YAML encoded remote state blocks to configure in the workspace | |
 | `runner_terraform_version` | Terraform version used to create the workspace | `1.0.3` |
 | `speculative_enabled` | Whether the workspace allows speculative plans | |
+| `skip_validate` | Whether to skip `terraform validate` for the proposed resources | `false` |
 | `ssh_key_id` | SSH key ID to assign the workspace | |
 | `team_access` | YAML encoded teams and their associated permissions to be granted to the created workspaces | `false` |
 | `terraform_version` | Terraform version | `1.0.3` |

--- a/action.yml
+++ b/action.yml
@@ -69,6 +69,9 @@ inputs:
     description: Whether the workspace should start automatically performing runs immediately after creation
   speculative_enabled:
     description: Whether the workspace allows speculative plans
+  skip_validate:
+    description: Whether to skip `terraform validate` for the proposed resources
+    default: false
   ssh_key_id:
     description: SSH key ID to assign the workspace
   file_triggers_enabled:

--- a/main.go
+++ b/main.go
@@ -188,6 +188,17 @@ func main() {
 		log.Fatalf("error running Init: %s", err)
 	}
 
+	if !inputs.GetBool("skip_validate") {
+		output, err := tf.Validate(ctx)
+		if err != nil {
+			log.Fatalf("error validating the workspace: %s", err)
+		}
+
+		if !output.Valid {
+			log.Fatalf("validation failure: %v", output.Diagnostics)
+		}
+	}
+
 	wsNames := make([]string, len(workspaces))
 	for i, ws := range workspaces {
 		wsNames[i] = ws.Name


### PR DESCRIPTION
Introduces `terraform validate` to the workflow. I've added an escape hatch,`skip_validation` for unforseen cases where one wouldn't want to validate.

A question though, does validation actually get us anything extra that a plan does not?

This wont help with configurations that are syntactically broken, as validate requires an init first, somewhat unfortunate but still a step in the right direction I think. 