### PR TITLE
fix md approver args order

### DIFF
--- a/.github/workflows/approve-md.yml
+++ b/.github/workflows/approve-md.yml
@@ -18,7 +18,7 @@ jobs:
       - id: diff
         name: git diff
         continue-on-error: true
-        run: git diff origin/${{ github.base_ref }} ':!**.md' --exit-code
+        run: git diff --exit-code origin/${{ github.base_ref }} ':!**.md'
       - uses: hmarr/auto-approve-action@v2
         if: ${{ steps.diff.outcome == 'success' }}
         with:


### PR DESCRIPTION
Missed in the workflow logs, `--exit-code` and other flags must come before positional args