### PR TITLE
Add golangci-lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,4 +15,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.29
+          version: v1.42

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,18 @@
+name: lint
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - master
+      - main
+  pull_request:
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.29

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,4 +15,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.42
+          version: v1.42.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,12 +1,13 @@
-name: lint
+name: Lint
 on:
   push:
-    tags:
-      - v*
     branches:
       - master
-      - main
+    paths-ignore:
+      - '**.md'
   pull_request:
+    paths-ignore:
+      - '**.md'
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,6 @@
+linters:
+  enable:
+    - bodyclose
+    - gci
+    - gofmt
+    - wsl

--- a/README.md
+++ b/README.md
@@ -182,3 +182,23 @@ with:
 | --- | --- |
 | `plan` | A human friendly output of the Terraform plan |
 | `plan_json` | A JSON representation of the Terraform plan |
+
+## Development
+
+### Test
+
+To test the project
+
+`go test`
+
+### Lint
+
+This project uses [`golangci-lint`](https://github.com/golangci/golangci-lint)
+
+To lint the project
+
+`golangci-lint run`
+
+To auto fix issues where supported
+
+`golangci-lint run  --fix`

--- a/import.go
+++ b/import.go
@@ -95,6 +95,7 @@ func GetWorkspace(ctx context.Context, client *tfe.Client, organization string, 
 		if err.Error() == "resource not found" {
 			return nil, nil
 		}
+
 		return nil, err
 	}
 

--- a/main.go
+++ b/main.go
@@ -13,9 +13,8 @@ import (
 	"github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-exec/tfexec"
 	"github.com/sethvargo/go-githubactions"
-	yaml "gopkg.in/yaml.v2"
-
 	"github.com/takescoop/terraform-cloud-workspace-action/internal/inputs"
+	yaml "gopkg.in/yaml.v2"
 )
 
 func main() {
@@ -90,12 +89,14 @@ func main() {
 	}
 
 	genVars := []Variable{}
+
 	err = yaml.Unmarshal([]byte(githubactions.GetInput("variables")), &genVars)
 	if err != nil {
 		log.Fatalf("Failed to parse variables %s", err)
 	}
 
 	wsVars := map[string][]Variable{}
+
 	err = yaml.Unmarshal([]byte(githubactions.GetInput("workspace_variables")), &wsVars)
 	if err != nil {
 		log.Fatalf("Failed to parse workspace variables %s", err)

--- a/team_access.go
+++ b/team_access.go
@@ -23,6 +23,7 @@ func MergeWorkspaceIDs(teamAccess []TeamAccess, workspaces []*Workspace) []TeamA
 	ts := make([]TeamAccess, len(teamAccess)*len(workspaces))
 
 	i := 0
+
 	for _, team := range teamAccess {
 		for _, ws := range workspaces {
 			team.WorkspaceName = ws.Name

--- a/variables.go
+++ b/variables.go
@@ -19,12 +19,14 @@ func findWorkspace(workspaces []*Workspace, target string) *Workspace {
 			return v
 		}
 	}
+
 	return nil
 }
 
 // ParseVariablesByWorkspace takes a list of workspace names, general variables and workspaced variables and flattens them into a single set
 func ParseVariablesByWorkspace(workspaces []*Workspace, generalVars *[]Variable, workspaceVars *map[string][]Variable) ([]Variable, error) {
 	vars := []Variable{}
+
 	for _, v := range *generalVars {
 		for _, ws := range workspaces {
 			newVar := v

--- a/workspace_test.go
+++ b/workspace_test.go
@@ -328,16 +328,17 @@ func TestAddRemoteStates(t *testing.T) {
 
 	foo := RemoteState{Backend: "S3", Config: RemoteStateBackendConfig{}}
 	bar := RemoteState{Backend: "S3", Config: RemoteStateBackendConfig{}}
+
 	wsConfig.AddRemoteStates(map[string]RemoteState{
 		"foo": foo,
 		"bar": bar,
 	})
+
 	assert.Equal(t, wsConfig.Data["terraform_remote_state"]["foo"], foo)
 	assert.Equal(t, wsConfig.Data["terraform_remote_state"]["bar"], bar)
 }
 
 func TestAddTeamAccess(t *testing.T) {
-
 	t.Run("Add basic team access", func(t *testing.T) {
 		ws := WorkspaceConfig{
 			Data:      map[string]map[string]interface{}{},


### PR DESCRIPTION
Adds golangci-lint and a readme blurb about how to lint and fix locally.

I added just a few of the default disabled linters that I thought sounded nice, but was sort of shooting in the dark so feel free to note any recommended ones