### PR TITLE
Add TeamAccess type to reference workpsaces

### DIFF
--- a/internal/action/main.go
+++ b/internal/action/main.go
@@ -135,13 +135,13 @@ func Run() {
 		log.Fatalf("Failed to parse teams: %s", err)
 	}
 
-	teamAccess := MergeWorkspaceIDs(teamInputs, workspaces)
-
-	for _, access := range teamAccess {
-		if err := access.Validate(); err != nil {
+	for _, teamInput := range teamInputs {
+		if err := teamInput.Validate(); err != nil {
 			log.Fatal(err)
 		}
 	}
+
+	teamAccess := NewTeamAccess(teamInputs, workspaces)
 
 	backend, err := tfconfig.ParseBackend(githubactions.GetInput("backend_config"))
 	if err != nil {
@@ -236,7 +236,7 @@ func Run() {
 		}
 
 		for _, access := range teamAccess {
-			if err = ImportTeamAccess(ctx, tf, client, org, access.WorkspaceName, access.TeamID, opts...); err != nil {
+			if err = ImportTeamAccess(ctx, tf, client, org, access.Workspace.Name, access.TeamID, opts...); err != nil {
 				log.Fatalf("Error importing team access: %s\n", err)
 			}
 		}

--- a/internal/action/team_access_test.go
+++ b/internal/action/team_access_test.go
@@ -6,40 +6,93 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestMergeWorkspaceIDs(t *testing.T) {
-	assert.Equal(t,
-		MergeWorkspaceIDs(
-			TeamAccessInput{
-				{Access: "read", TeamName: "readers"},
-				{Access: "write", TeamName: "writers"},
-			},
-			[]*Workspace{
-				{Name: "api-staging", Workspace: "staging"},
-				{Name: "api-production", Workspace: "staging"},
-			},
-		),
-		TeamAccessInput{
-			{Access: "read", TeamName: "readers", WorkspaceName: "api-staging"},
-			{Access: "read", TeamName: "readers", WorkspaceName: "api-production"},
-			{Access: "write", TeamName: "writers", WorkspaceName: "api-staging"},
-			{Access: "write", TeamName: "writers", WorkspaceName: "api-production"},
-		},
-	)
-}
-
 func TestTeamAccessValidate(t *testing.T) {
 	t.Run("valid with team name", func(t *testing.T) {
-		access := TeamAccessInputItem{TeamName: "foo", WorkspaceName: "workspace"}
+		access := TeamAccessInputItem{TeamName: "foo"}
 		assert.NoError(t, access.Validate())
 	})
 
 	t.Run("valid with team ID", func(t *testing.T) {
-		access := TeamAccessInputItem{TeamID: "team-abc123", WorkspaceName: "workspace"}
+		access := TeamAccessInputItem{TeamID: "team-abc123"}
 		assert.NoError(t, access.Validate())
 	})
 
 	t.Run("not valid with team ID and team name", func(t *testing.T) {
-		access := TeamAccessInputItem{TeamName: "foo", TeamID: "team-abc123", WorkspaceName: "workspace"}
+		access := TeamAccessInputItem{TeamName: "foo", TeamID: "team-abc123"}
 		assert.Error(t, access.Validate())
 	})
+}
+
+type NewTeamAccessTestCase struct {
+	Description string
+	Workspaces  []*Workspace
+	Input       TeamAccessInput
+	Expect      TeamAccess
+}
+
+func TestNewTeamAccess(t *testing.T) {
+	for _, testCase := range []NewTeamAccessTestCase{
+		{
+			Description: "single access, single workspace",
+			Workspaces: []*Workspace{
+				{Name: "staging"},
+			},
+			Input: TeamAccessInput{
+				TeamAccessInputItem{Access: "read", TeamName: "Readers"},
+			},
+			Expect: TeamAccess{
+				TeamAccessItem{Access: "read", TeamName: "Readers", Workspace: &Workspace{Name: "staging"}},
+			},
+		},
+		{
+			Description: "single access, multi workspace",
+			Workspaces: []*Workspace{
+				{Name: "staging"},
+				{Name: "production"},
+			},
+			Input: TeamAccessInput{
+				TeamAccessInputItem{Access: "read", TeamName: "Readers"},
+			},
+			Expect: TeamAccess{
+				TeamAccessItem{Access: "read", TeamName: "Readers", Workspace: &Workspace{Name: "staging"}},
+				TeamAccessItem{Access: "read", TeamName: "Readers", Workspace: &Workspace{Name: "production"}},
+			},
+		},
+		{
+			Description: "multi access, single workspace",
+			Workspaces: []*Workspace{
+				{Name: "staging"},
+			},
+			Input: TeamAccessInput{
+				TeamAccessInputItem{Access: "read", TeamName: "Readers"},
+				TeamAccessInputItem{Access: "write", TeamName: "Writers"},
+			},
+			Expect: TeamAccess{
+				TeamAccessItem{Access: "read", TeamName: "Readers", Workspace: &Workspace{Name: "staging"}},
+				TeamAccessItem{Access: "write", TeamName: "Writers", Workspace: &Workspace{Name: "staging"}},
+			},
+		},
+		{
+			Description: "multi access, multi workspace",
+			Workspaces: []*Workspace{
+				{Name: "staging"},
+				{Name: "production"},
+			},
+			Input: TeamAccessInput{
+				TeamAccessInputItem{Access: "read", TeamName: "Readers"},
+				TeamAccessInputItem{Access: "write", TeamName: "Writers"},
+			},
+			Expect: TeamAccess{
+				TeamAccessItem{Access: "read", TeamName: "Readers", Workspace: &Workspace{Name: "staging"}},
+				TeamAccessItem{Access: "read", TeamName: "Readers", Workspace: &Workspace{Name: "production"}},
+				TeamAccessItem{Access: "write", TeamName: "Writers", Workspace: &Workspace{Name: "staging"}},
+				TeamAccessItem{Access: "write", TeamName: "Writers", Workspace: &Workspace{Name: "production"}},
+			},
+		},
+	} {
+		t.Run(testCase.Description, func(t *testing.T) {
+			access := NewTeamAccess(testCase.Input, testCase.Workspaces)
+			assert.Equal(t, access, testCase.Expect)
+		})
+	}
 }

--- a/internal/action/workspace.go
+++ b/internal/action/workspace.go
@@ -140,7 +140,7 @@ type TeamDataResource struct {
 }
 
 // AppendTeamAccess adds the passed teams to the calling workspace
-func AppendTeamAccess(module *tfconfig.Module, teamAccess TeamAccessInput, organization string) {
+func AppendTeamAccess(module *tfconfig.Module, teamAccess TeamAccess, organization string) {
 	if len(teamAccess) == 0 {
 		return
 	}

--- a/internal/action/workspace.go
+++ b/internal/action/workspace.go
@@ -155,7 +155,7 @@ type TeamDataResource struct {
 }
 
 // AddTeamAccess adds the passed teams to the calling workspace
-func AddTeamAccess(module *tfconfig.Module, teamAccess TeamAccessInput, organization string) {
+func AddTeamAccess(module *tfconfig.Module, teamAccess TeamAccess, organization string) {
 	if len(teamAccess) == 0 {
 		return
 	}
@@ -175,9 +175,9 @@ func AddTeamAccess(module *tfconfig.Module, teamAccess TeamAccessInput, organiza
 			teamIDRef = fmt.Sprintf("${data.tfe_team.teams[\"%s\"].id}", access.TeamName)
 		}
 
-		resourceForEach[fmt.Sprintf("%s-%s", access.WorkspaceName, teamIDRef)] = tfeprovider.TeamAccess{
+		resourceForEach[fmt.Sprintf("%s-%s", access.Workspace.Name, teamIDRef)] = tfeprovider.TeamAccess{
 			TeamID:      teamIDRef,
-			WorkspaceID: fmt.Sprintf("${tfe_workspace.workspace[%q].id}", access.WorkspaceName),
+			WorkspaceID: fmt.Sprintf("${tfe_workspace.workspace[%q].id}", access.Workspace.Name),
 			Access:      access.Access,
 			Permissions: access.ToResource().Permissions,
 		}
@@ -233,7 +233,7 @@ type NewWorkspaceConfigOptions struct {
 	WorkspaceVariables       map[string]tfconfig.Variable
 	RemoteStates             map[string]tfconfig.RemoteState
 	Variables                Variables
-	TeamAccess               TeamAccessInput
+	TeamAccess               TeamAccess
 	WorkspaceResourceOptions *WorkspaceResourceOptions
 	Providers                []Provider
 }
@@ -299,23 +299,6 @@ func WillDestroy(plan *tfjson.Plan, targetType string) bool {
 	}
 
 	return false
-}
-
-// MergeWorkspaceIDs returns a new slice of TeamAccess structs
-func MergeWorkspaceIDs(teamAccess TeamAccessInput, workspaces []*Workspace) TeamAccessInput {
-	ts := make(TeamAccessInput, len(teamAccess)*len(workspaces))
-
-	i := 0
-
-	for _, team := range teamAccess {
-		for _, ws := range workspaces {
-			team.WorkspaceName = ws.Name
-			ts[i] = team
-			i = i + 1
-		}
-	}
-
-	return ts
 }
 
 // FindWorkspace returns a workspace that matches the passed Terraform workspace identifier (not the workspace name)

--- a/internal/action/workspace_test.go
+++ b/internal/action/workspace_test.go
@@ -330,9 +330,9 @@ func TestAddTeamAccess(t *testing.T) {
 			Resources: map[string]map[string]interface{}{},
 		}
 
-		AddTeamAccess(module, TeamAccessInput{
-			{TeamName: "Readers", Access: "read", WorkspaceName: "workspace"},
-			{TeamName: "Writers", Access: "write", WorkspaceName: "workspace"},
+		AddTeamAccess(module, TeamAccess{
+			TeamAccessItem{TeamName: "Readers", Access: "read", Workspace: &Workspace{Name: "workspace"}},
+			TeamAccessItem{TeamName: "Writers", Access: "write", Workspace: &Workspace{Name: "workspace"}},
 		}, "org")
 
 		assert.Equal(t, module.Data["tfe_team"]["teams"], TeamDataResource{
@@ -387,9 +387,9 @@ func TestAddTeamAccess(t *testing.T) {
 			Resources: map[string]map[string]interface{}{},
 		}
 
-		AddTeamAccess(module, TeamAccessInput{
-			{TeamName: "Writers", Access: "write", WorkspaceName: "workspace"},
-			{TeamID: "team-12345", Access: "read", WorkspaceName: "workspace"},
+		AddTeamAccess(module, TeamAccess{
+			TeamAccessItem{TeamName: "Writers", Access: "write", Workspace: &Workspace{Name: "workspace"}},
+			TeamAccessItem{TeamID: "team-12345", Access: "read", Workspace: &Workspace{Name: "workspace"}},
 		}, "org")
 
 		assert.Equal(t, module.Data["tfe_team"]["teams"].(TeamDataResource).ForEach, map[string]TeamDataResource{
@@ -419,9 +419,9 @@ func TestAddTeamAccess(t *testing.T) {
 			Resources: map[string]map[string]interface{}{},
 		}
 
-		AddTeamAccess(module, TeamAccessInput{
-			{TeamID: "team-12345", Access: "write", WorkspaceName: "workspace"},
-			{TeamID: "team-67890", Access: "read", WorkspaceName: "workspace"},
+		AddTeamAccess(module, TeamAccess{
+			TeamAccessItem{TeamID: "team-12345", Access: "write", Workspace: &Workspace{Name: "workspace"}},
+			TeamAccessItem{TeamID: "team-67890", Access: "read", Workspace: &Workspace{Name: "workspace"}},
 		}, "org")
 
 		assert.Equal(t, module.Data["tfe_team"]["teams"], nil)
@@ -446,8 +446,11 @@ func TestAddTeamAccess(t *testing.T) {
 			Resources: map[string]map[string]interface{}{},
 		}
 
-		AddTeamAccess(module, TeamAccessInput{
-			{TeamID: "${data.terraform_remote_state.teams.output.teams[\"team\"].id}", Access: "write", WorkspaceName: "workspace"},
+		AddTeamAccess(module, TeamAccess{
+			TeamAccessItem{
+				TeamID:    "${data.terraform_remote_state.teams.output.teams[\"team\"].id}",
+				Access:    "write",
+				Workspace: &Workspace{Name: "workspace"}},
 		}, "org")
 
 		assert.Equal(t, module.Data["tfe_team"]["teams"], nil)
@@ -467,8 +470,8 @@ func TestAddTeamAccess(t *testing.T) {
 			Resources: map[string]map[string]interface{}{},
 		}
 
-		AddTeamAccess(module, TeamAccessInput{
-			{TeamName: "Readers", WorkspaceName: "workspace", Permissions: &TeamAccessPermissionsInput{
+		AddTeamAccess(module, TeamAccess{
+			{TeamName: "Readers", Workspace: &Workspace{Name: "workspace"}, Permissions: &TeamAccessPermissionsInput{
 				Runs:             "read",
 				Variables:        "read",
 				StateVersions:    "none",
@@ -708,16 +711,16 @@ func TestNewWorkspaceConfig(t *testing.T) {
 					},
 				},
 			},
-			TeamAccess: TeamAccessInput{
-				{TeamName: "Readers", WorkspaceName: name, Access: "read"},
-				{TeamName: "Writers", WorkspaceName: name, Permissions: &TeamAccessPermissionsInput{
+			TeamAccess: TeamAccess{
+				TeamAccessItem{TeamName: "Readers", Workspace: &Workspace{Name: name}, Access: "read"},
+				TeamAccessItem{TeamName: "Writers", Workspace: &Workspace{Name: name}, Permissions: &TeamAccessPermissionsInput{
 					Runs:             "read",
 					Variables:        "read",
 					StateVersions:    "read",
 					SentinelMocks:    "none",
 					WorkspaceLocking: true,
 				}},
-				{TeamName: "${data.terraform_remote_state.teams.outputs.team}", WorkspaceName: name, Access: "read"},
+				TeamAccessItem{TeamName: "${data.terraform_remote_state.teams.outputs.team}", Workspace: &Workspace{Name: name}, Access: "read"},
 			},
 		})
 		if err != nil {


### PR DESCRIPTION
Similar to #46, adds TeamAccess and TeamAccessItem types to use within the action. These two types will hold reference to the associated workspace, freeing TeamAccessInput to be used for reading in and validating GitHub action input, and tfeprovider.TeamAccess to marshal into Terraform config. The new types should be passed around the action to facilitate actions like importing, which require a reference to the workspace.

This one touches some of the same code that #47 does, so once we get that one in good shape and merged I'll merge that into this one.