### PR TITLE
Allow use of arbitrary backend configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ jobs:
 
 ### Backend Config
 
-This project supports arbitrary backend configuration. Any configuration passed via `backend_config` will be directly added to the workspcae configuration.
+This project supports any backend supported by the selected Terraform version. The backend is used to persist the state of the Terraform Cloud workspace itself and its related resources (e.g., variables, teams). You generally should not pass "remote" workspace configuration, since that creates a circular dependency. 
 
 ```yml
 with:

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ jobs:
 
 ### Backend Config
 
-This project supports two backend types, `s3` and `local`
+This project supports arbitrary backend configuration. Any configuration passed via `backend_config` will be directly added to the workspcae configuration.
 
 ```yml
 with:
@@ -73,6 +73,14 @@ with:
       role_arn: arn:aws:iam::123456789:role/terraform
       access_key: xxx
       secret_key: xxx
+```
+
+```yml
+with:
+  ...
+  backend_config: |-
+    local:
+      path: path/to/my/terraform.tfstate
 ```
 
 ### Variables and Workspace Variables

--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ jobs:
 
 This project supports any backend supported by the selected Terraform version. The backend is used to persist the state of the Terraform Cloud workspace itself and its related resources (e.g., variables, teams). You generally should not pass "remote" workspace configuration, since that creates a circular dependency. 
 
+If no backend is passed, the default Terraform local backend will be used.
+**NOTE** When using the default local backend, `import` will always be true to ensure that resources can be managed across action runs. 
+
 ```yml
 with:
   ...
@@ -73,14 +76,6 @@ with:
       role_arn: arn:aws:iam::123456789:role/terraform
       access_key: xxx
       secret_key: xxx
-```
-
-```yml
-with:
-  ...
-  backend_config: |-
-    local:
-      path: path/to/my/terraform.tfstate
 ```
 
 ### Variables and Workspace Variables

--- a/go.mod
+++ b/go.mod
@@ -9,4 +9,5 @@ require (
 	github.com/sethvargo/go-githubactions v0.4.0
 	github.com/stretchr/testify v1.7.0
 	gopkg.in/yaml.v2 v2.4.0
+	sigs.k8s.io/yaml v1.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -296,6 +296,7 @@ gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
@@ -305,3 +306,5 @@ honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
+sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
+sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=

--- a/internal/action/main.go
+++ b/internal/action/main.go
@@ -213,7 +213,7 @@ func Run() {
 		tfexec.Var(fmt.Sprintf("workspace_names=%s", string(wsBytes))),
 	}
 
-	if inputs.GetBool("import") {
+	if inputs.GetBool("import") || backend == nil {
 		fmt.Println("Importing resources...")
 
 		opts := make([]tfexec.ImportOption, len(varOpts))

--- a/internal/action/workspace.go
+++ b/internal/action/workspace.go
@@ -197,7 +197,7 @@ func AppendTeamAccess(module *tfconfig.Module, teamAccess TeamAccess, organizati
 }
 
 type NewWorkspaceConfigOptions struct {
-	Backend                  *tfconfig.Backend
+	Backend                  map[string]interface{}
 	WorkspaceVariables       map[string]tfconfig.Variable
 	RemoteStates             map[string]tfconfig.RemoteState
 	Variables                Variables
@@ -215,7 +215,7 @@ func NewWorkspaceConfig(ctx context.Context, client *tfe.Client, config *NewWork
 
 	module := &tfconfig.Module{
 		Terraform: tfconfig.Terraform{
-			Backend: *config.Backend,
+			Backend: config.Backend,
 		},
 		Variables: config.WorkspaceVariables,
 		Data:      map[string]map[string]interface{}{},

--- a/internal/action/workspace.go
+++ b/internal/action/workspace.go
@@ -214,9 +214,7 @@ func NewWorkspaceConfig(ctx context.Context, client *tfe.Client, config *NewWork
 	}
 
 	module := &tfconfig.Module{
-		Terraform: tfconfig.Terraform{
-			Backend: config.Backend,
-		},
+		Terraform: tfconfig.Terraform{},
 		Variables: config.WorkspaceVariables,
 		Data:      map[string]map[string]interface{}{},
 		Resources: map[string]map[string]interface{}{
@@ -224,6 +222,10 @@ func NewWorkspaceConfig(ctx context.Context, client *tfe.Client, config *NewWork
 				"workspace": wsResource,
 			},
 		},
+	}
+
+	if config.Backend != nil {
+		module.Terraform.Backend = config.Backend
 	}
 
 	for name, rs := range config.RemoteStates {

--- a/internal/action/workspace_test.go
+++ b/internal/action/workspace_test.go
@@ -590,8 +590,33 @@ func TestNewWorkspaceConfig(t *testing.T) {
 
 	t.Run("validate basic workspace config", func(t *testing.T) {
 		wsConfig, err := NewWorkspaceConfig(ctx, client, &NewWorkspaceConfigOptions{
+			WorkspaceResourceOptions: &WorkspaceResourceOptions{
+				Organization: "org",
+			},
+			WorkspaceVariables: map[string]tfconfig.Variable{
+				"workspace_names": {
+					Type: "set(string)",
+				},
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		output, err := RunValidate(ctx, name, execPath, wsConfig)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Equal(t, output.Valid, true, output.Diagnostics)
+	})
+
+	t.Run("validate using a passed backend", func(t *testing.T) {
+		wsConfig, err := NewWorkspaceConfig(ctx, client, &NewWorkspaceConfigOptions{
 			Backend: map[string]interface{}{
-				"local": map[string]interface{}{},
+				"local": map[string]interface{}{
+					"path": "foo/terraform.tfstate",
+				},
 			},
 			WorkspaceResourceOptions: &WorkspaceResourceOptions{
 				Organization: "org",
@@ -616,9 +641,6 @@ func TestNewWorkspaceConfig(t *testing.T) {
 
 	t.Run("validate workspace with passed providers", func(t *testing.T) {
 		wsConfig, err := NewWorkspaceConfig(ctx, client, &NewWorkspaceConfigOptions{
-			Backend: map[string]interface{}{
-				"local": map[string]interface{}{},
-			},
 			Providers: []Provider{
 				{
 					Name:    "tfe",
@@ -652,9 +674,6 @@ func TestNewWorkspaceConfig(t *testing.T) {
 
 	t.Run("validate workspace with remote states", func(t *testing.T) {
 		wsConfig, err := NewWorkspaceConfig(ctx, client, &NewWorkspaceConfigOptions{
-			Backend: map[string]interface{}{
-				"local": map[string]interface{}{},
-			},
 			WorkspaceResourceOptions: &WorkspaceResourceOptions{
 				Organization: "org",
 			},
@@ -688,9 +707,6 @@ func TestNewWorkspaceConfig(t *testing.T) {
 
 	t.Run("validate workspace with team access", func(t *testing.T) {
 		wsConfig, err := NewWorkspaceConfig(ctx, client, &NewWorkspaceConfigOptions{
-			Backend: map[string]interface{}{
-				"local": map[string]interface{}{},
-			},
 			WorkspaceResourceOptions: &WorkspaceResourceOptions{
 				Organization: "org",
 			},
@@ -737,9 +753,6 @@ func TestNewWorkspaceConfig(t *testing.T) {
 
 	t.Run("validate workspace with variables", func(t *testing.T) {
 		wsConfig, err := NewWorkspaceConfig(ctx, client, &NewWorkspaceConfigOptions{
-			Backend: map[string]interface{}{
-				"local": map[string]interface{}{},
-			},
 			WorkspaceResourceOptions: &WorkspaceResourceOptions{
 				Organization: "org",
 			},

--- a/internal/action/workspace_test.go
+++ b/internal/action/workspace_test.go
@@ -590,8 +590,8 @@ func TestNewWorkspaceConfig(t *testing.T) {
 
 	t.Run("validate basic workspace config", func(t *testing.T) {
 		wsConfig, err := NewWorkspaceConfig(ctx, client, &NewWorkspaceConfigOptions{
-			Backend: &tfconfig.Backend{
-				Local: &tfconfig.LocalBackend{},
+			Backend: map[string]interface{}{
+				"local": map[string]interface{}{},
 			},
 			WorkspaceResourceOptions: &WorkspaceResourceOptions{
 				Organization: "org",
@@ -616,8 +616,8 @@ func TestNewWorkspaceConfig(t *testing.T) {
 
 	t.Run("validate workspace with passed providers", func(t *testing.T) {
 		wsConfig, err := NewWorkspaceConfig(ctx, client, &NewWorkspaceConfigOptions{
-			Backend: &tfconfig.Backend{
-				Local: &tfconfig.LocalBackend{},
+			Backend: map[string]interface{}{
+				"local": map[string]interface{}{},
 			},
 			Providers: []Provider{
 				{
@@ -652,8 +652,8 @@ func TestNewWorkspaceConfig(t *testing.T) {
 
 	t.Run("validate workspace with remote states", func(t *testing.T) {
 		wsConfig, err := NewWorkspaceConfig(ctx, client, &NewWorkspaceConfigOptions{
-			Backend: &tfconfig.Backend{
-				Local: &tfconfig.LocalBackend{},
+			Backend: map[string]interface{}{
+				"local": map[string]interface{}{},
 			},
 			WorkspaceResourceOptions: &WorkspaceResourceOptions{
 				Organization: "org",
@@ -688,8 +688,8 @@ func TestNewWorkspaceConfig(t *testing.T) {
 
 	t.Run("validate workspace with team access", func(t *testing.T) {
 		wsConfig, err := NewWorkspaceConfig(ctx, client, &NewWorkspaceConfigOptions{
-			Backend: &tfconfig.Backend{
-				Local: &tfconfig.LocalBackend{},
+			Backend: map[string]interface{}{
+				"local": map[string]interface{}{},
 			},
 			WorkspaceResourceOptions: &WorkspaceResourceOptions{
 				Organization: "org",
@@ -737,8 +737,8 @@ func TestNewWorkspaceConfig(t *testing.T) {
 
 	t.Run("validate workspace with variables", func(t *testing.T) {
 		wsConfig, err := NewWorkspaceConfig(ctx, client, &NewWorkspaceConfigOptions{
-			Backend: &tfconfig.Backend{
-				Local: &tfconfig.LocalBackend{},
+			Backend: map[string]interface{}{
+				"local": map[string]interface{}{},
 			},
 			WorkspaceResourceOptions: &WorkspaceResourceOptions{
 				Organization: "org",

--- a/internal/tfconfig/backends.go
+++ b/internal/tfconfig/backends.go
@@ -1,66 +1,22 @@
 package tfconfig
 
 import (
-	"fmt"
+	"encoding/json"
 
-	yaml "gopkg.in/yaml.v2"
+	yaml "sigs.k8s.io/yaml"
 )
 
-type Backend struct {
-	S3    *S3Backend    `yaml:"s3,omitempty" json:"s3,omitempty"`
-	Local *LocalBackend `yaml:"s3,omitempty" json:"local,omitempty"`
-}
-
-// TODO: Support arbitrary backend types
-// Avoid parsing into sepcific structs for specific backend types
-
-type S3Backend struct {
-	Bucket    string `yaml:"bucket" json:"bucket"`
-	Key       string `yaml:"key" json:"key"`
-	Region    string `yaml:"region" json:"region"`
-	AccessKey string `yaml:"access_key" json:"access_key,omitempty"`
-	SecretKey string `yaml:"secret_key" json:"secret_key,omitempty"`
-	RoleArn   string `yaml:"role_arn" json:"role_arn,omitempty"`
-}
-
-type LocalBackend struct {
-	Path string `json:"path,omitempty"`
-}
-
-func ParseBackend(backendInput string) (*Backend, error) {
-	var backend map[string]interface{}
-
-	wsBackend := &Backend{}
-
-	if err := yaml.Unmarshal([]byte(backendInput), &backend); err != nil {
+func ParseBackend(backendInput string) (map[string]interface{}, error) {
+	j, err := yaml.YAMLToJSON([]byte(backendInput))
+	if err != nil {
 		return nil, err
 	}
 
-	if _, ok := backend["s3"]; ok {
-		var s3Backend map[string]S3Backend
+	var backend map[string]interface{}
 
-		if err := yaml.Unmarshal([]byte(backendInput), &s3Backend); err != nil {
-			return nil, err
-		}
-
-		be := s3Backend["s3"]
-		wsBackend.S3 = &be
-
-		return wsBackend, nil
+	if err = json.Unmarshal(j, &backend); err != nil {
+		return nil, err
 	}
 
-	if _, ok := backend["local"]; ok {
-		var localBackend map[string]LocalBackend
-
-		if err := yaml.Unmarshal([]byte(backendInput), &localBackend); err != nil {
-			return nil, err
-		}
-
-		be := localBackend["local"]
-		wsBackend.Local = &be
-
-		return wsBackend, nil
-	}
-
-	return nil, fmt.Errorf("unsupported backend type %v", backend)
+	return backend, nil
 }

--- a/internal/tfconfig/backends.go
+++ b/internal/tfconfig/backends.go
@@ -6,7 +6,12 @@ import (
 	yaml "sigs.k8s.io/yaml"
 )
 
+// Returns a generic backend object that can be directly added to the Terraform config, will return nil if no backend is set
 func ParseBackend(backendInput string) (map[string]interface{}, error) {
+	if backendInput == "" {
+		return nil, nil
+	}
+
 	j, err := yaml.YAMLToJSON([]byte(backendInput))
 	if err != nil {
 		return nil, err

--- a/internal/tfconfig/backends_test.go
+++ b/internal/tfconfig/backends_test.go
@@ -58,4 +58,11 @@ foo:
 		assert.Contains(t, be["foo"], "bar")
 		assert.Equal(t, be["foo"].(map[string]interface{})["bar"], "baz")
 	})
+
+	t.Run("Parse empty backend", func(t *testing.T) {
+		be, err := ParseBackend("")
+
+		assert.NoError(t, err)
+		assert.Equal(t, be, (map[string]interface{})(nil))
+	})
 }

--- a/internal/tfconfig/backends_test.go
+++ b/internal/tfconfig/backends_test.go
@@ -18,32 +18,44 @@ s3:
 		be, err := ParseBackend(config)
 		assert.NoError(t, err)
 
-		assert.Equal(t, be.S3.Bucket, "foo")
-		assert.Equal(t, be.S3.Key, "bar")
-		assert.Equal(t, be.S3.Region, "us-east-1")
-		assert.Equal(t, be.Local, (*LocalBackend)(nil))
+		assert.Contains(t, be, "s3")
+
+		assert.Contains(t, be["s3"], "bucket")
+		assert.Equal(t, be["s3"].(map[string]interface{})["bucket"], "foo")
+
+		assert.Contains(t, be["s3"], "key")
+		assert.Equal(t, be["s3"].(map[string]interface{})["key"], "bar")
+
+		assert.Contains(t, be["s3"], "region")
+		assert.Equal(t, be["s3"].(map[string]interface{})["region"], "us-east-1")
 	})
 
-	t.Run("Parse Local backend with minimal inputs", func(t *testing.T) {
+	t.Run("Parse local backend with minimal inputs", func(t *testing.T) {
 		config := `---
 local:
   path: foo/terraform.tfstate
+`
+		be, err := ParseBackend(config)
+		assert.NoError(t, err)
+
+		assert.Contains(t, be, "local")
+
+		assert.Contains(t, be["local"], "path")
+		assert.Equal(t, be["local"].(map[string]interface{})["path"], "foo/terraform.tfstate")
+	})
+
+	t.Run("Parse any generic backend", func(t *testing.T) {
+		config := `---
+foo:
+  bar: baz
 `
 
 		be, err := ParseBackend(config)
 		assert.NoError(t, err)
 
-		assert.Equal(t, be.Local.Path, "foo/terraform.tfstate")
-		assert.Equal(t, be.S3, (*S3Backend)(nil))
-	})
+		assert.Contains(t, be, "foo")
 
-	t.Run("Error on unsupported backend type", func(t *testing.T) {
-		config := `---
-pg:
-	conn_str: postgres://user:pass@db.example.com/terraform_backend
-`
-
-		_, err := ParseBackend(config)
-		assert.Error(t, err)
+		assert.Contains(t, be["foo"], "bar")
+		assert.Equal(t, be["foo"].(map[string]interface{})["bar"], "baz")
 	})
 }

--- a/internal/tfconfig/terraform.go
+++ b/internal/tfconfig/terraform.go
@@ -1,7 +1,7 @@
 package tfconfig
 
 type Terraform struct {
-	Backend           Backend                     `json:"backend"`
+	Backend           map[string]interface{}      `json:"backend"`
 	RequiredVersion   string                      `json:"required_version,omitempty"`
 	RequiredProviders map[string]RequiredProvider `json:"required_providers,omitempty"`
 }

--- a/internal/tfconfig/terraform.go
+++ b/internal/tfconfig/terraform.go
@@ -1,7 +1,7 @@
 package tfconfig
 
 type Terraform struct {
-	Backend           map[string]interface{}      `json:"backend"`
+	Backend           map[string]interface{}      `json:"backend,omitempty"`
 	RequiredVersion   string                      `json:"required_version,omitempty"`
 	RequiredProviders map[string]RequiredProvider `json:"required_providers,omitempty"`
 }


### PR DESCRIPTION
Takes the input from backend_config (yaml) and parses it directly into json, which is then directly added to the tf config under the "backend" key