### PR TITLE
Add basic import test

### DIFF
--- a/internal/action/import.go
+++ b/internal/action/import.go
@@ -13,7 +13,7 @@ import (
 
 var maxPageSize int = 100
 
-func shouldImport(ctx context.Context, tf TFExecClient, address string) (bool, error) {
+func shouldImport(ctx context.Context, tf TerraformCLI, address string) (bool, error) {
 	state, err := tf.Show(ctx)
 	if err != nil {
 		return false, err
@@ -32,12 +32,12 @@ func shouldImport(ctx context.Context, tf TFExecClient, address string) (bool, e
 	return true, nil
 }
 
-type TFExecClient interface {
+type TerraformCLI interface {
 	Show(context.Context, ...tfexec.ShowOption) (*tfjson.State, error)
 	Import(context.Context, string, string, ...tfexec.ImportOption) error
 }
 
-func ImportWorkspace(ctx context.Context, tf TFExecClient, client *tfe.Client, name string, organization string, opts ...tfexec.ImportOption) error {
+func ImportWorkspace(ctx context.Context, tf TerraformCLI, client *tfe.Client, name string, organization string, opts ...tfexec.ImportOption) error {
 	address := fmt.Sprintf("tfe_workspace.workspace[%q]", name)
 
 	imp, err := shouldImport(ctx, tf, address)
@@ -109,7 +109,7 @@ func GetWorkspace(ctx context.Context, client *tfe.Client, organization string, 
 	return ws, nil
 }
 
-func ImportVariable(ctx context.Context, tf TFExecClient, client *tfe.Client, key string, workspace string, organization string, opts ...tfexec.ImportOption) error {
+func ImportVariable(ctx context.Context, tf TerraformCLI, client *tfe.Client, key string, workspace string, organization string, opts ...tfexec.ImportOption) error {
 	address := fmt.Sprintf("tfe_variable.%s-%s", workspace, key)
 
 	imp, err := shouldImport(ctx, tf, address)
@@ -157,7 +157,7 @@ func ImportVariable(ctx context.Context, tf TFExecClient, client *tfe.Client, ke
 }
 
 // ImportTeamAccess imports a team access resource by looking up an existing relation
-func ImportTeamAccess(ctx context.Context, tf TFExecClient, client *tfe.Client, organization string, workspace string, teamID string, opts ...tfexec.ImportOption) error {
+func ImportTeamAccess(ctx context.Context, tf TerraformCLI, client *tfe.Client, organization string, workspace string, teamID string, opts ...tfexec.ImportOption) error {
 	if teamID == "" {
 		githubactions.Infof("Skipping team access import, required team ID was not passed\n")
 		return nil

--- a/internal/action/import_test.go
+++ b/internal/action/import_test.go
@@ -15,7 +15,7 @@ import (
 
 type TestTFExec struct {
 	State      *tfjson.State
-	ImportArgs *ImportArgs
+	ImportArgs []*ImportArgs
 }
 
 type ImportArgs struct {
@@ -29,11 +29,11 @@ func (tf TestTFExec) Show(ctx context.Context, opts ...tfexec.ShowOption) (*tfjs
 }
 
 func (tf *TestTFExec) Import(ctx context.Context, address string, ID string, opts ...tfexec.ImportOption) error {
-	tf.ImportArgs = &ImportArgs{
+	tf.ImportArgs = append(tf.ImportArgs, &ImportArgs{
 		Address: address,
 		ID:      ID,
 		Opts:    opts,
-	}
+	})
 
 	return nil
 }
@@ -80,7 +80,7 @@ func TestImportWorkspace(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		assert.Equal(t, tf.ImportArgs, (*ImportArgs)(nil))
+		assert.Equal(t, len(tf.ImportArgs), 0)
 	})
 
 	t.Run("import the workspace if it does not exist in state", func(t *testing.T) {
@@ -92,7 +92,8 @@ func TestImportWorkspace(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		assert.Equal(t, tf.ImportArgs, &ImportArgs{
+		assert.Equal(t, len(tf.ImportArgs), 1)
+		assert.Equal(t, tf.ImportArgs[0], &ImportArgs{
 			Address: "tfe_workspace.workspace[\"ws\"]",
 			ID:      "ws-abc123",
 			Opts:    ([]tfexec.ImportOption)(nil),


### PR DESCRIPTION
Adds a few basic tests for importing a workspace. 

Any thoughts on creating the TF workspace API response? I couldn't find the struct in a package, as I don't _think_ the terraform cloud API code itself is open source? Could be wrong. 

Changes:
Import now takes an tfexec interface that forces implementation of the two methods we use there, Show and Import