### PR TITLE
Force team name use for team access

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,9 @@ with:
         value: production
 ```
 
-### Remote States
+#### Remote state variable reference
 
-Remote states can be configured and referenced from other input fields
+Remote states can be configured and referenced for the variable `value` field
 
 ```yml
 ...
@@ -145,19 +145,6 @@ with:
         state_versions: write
         sentinel_mocks: read
         workspace_locking: true
-```
-
-To import existing team access resources, a static value for team `id` must be supplied
-
-```yml
-with:
-  import: true
-  team_access: |-
-    - id: team-abc123 # this is correct
-      access: write
-    - id: ${data.terraform_remote_state.tfe.outputs.teams["Engineering"].id} # this will error
-      access: read
-      
 ```
 
 ### Importing existing resources

--- a/README.md
+++ b/README.md
@@ -138,22 +138,13 @@ with:
   team_access: |-
     - name: Readers
       access: read
-    - id: team-abc123
-      access: write
-    - name: ${data.terraform_remote_state.tfe.outputs.teams["Engineering"].name}
+    - name: Writers
       permissions:
-        runs: read
-        variables: read
-        state_versions: read
+        runs: apply
+        variables: write
+        state_versions: write
         sentinel_mocks: read
         workspace_locking: true
-  remote_states: |-
-    tfe:
-      backend: remote
-      config:
-        bucket: s3-bucket
-        key: terraform.tfstate
-        region: us-east-1
 ```
 
 To import existing team access resources, a static value for team `id` must be supplied

--- a/internal/action/import.go
+++ b/internal/action/import.go
@@ -3,7 +3,6 @@ package action
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-exec/tfexec"
@@ -157,17 +156,8 @@ func ImportVariable(ctx context.Context, tf TerraformCLI, client *tfe.Client, ke
 }
 
 // ImportTeamAccess imports a team access resource by looking up an existing relation
-func ImportTeamAccess(ctx context.Context, tf TerraformCLI, client *tfe.Client, organization string, workspace string, teamID string, opts ...tfexec.ImportOption) error {
-	if teamID == "" {
-		githubactions.Infof("Skipping team access import, required team ID was not passed\n")
-		return nil
-	}
-
-	if !strings.HasPrefix(teamID, "team-") {
-		return fmt.Errorf("team ID passed for team access import, but it was not of the static format team-xxx: %s", teamID)
-	}
-
-	address := fmt.Sprintf("tfe_team_access.teams[\"%s-%s\"]", workspace, teamID)
+func ImportTeamAccess(ctx context.Context, tf TerraformCLI, client *tfe.Client, organization string, workspace string, teamName string, opts ...tfexec.ImportOption) error {
+	address := fmt.Sprintf("tfe_team_access.teams[\"%s-%s\"]", workspace, teamName)
 
 	imp, err := shouldImport(ctx, tf, address)
 	if err != nil {
@@ -201,13 +191,13 @@ func ImportTeamAccess(ctx context.Context, tf TerraformCLI, client *tfe.Client, 
 	var teamAccessID string
 
 	for _, access := range teamAccess.Items {
-		if access.Team.ID == teamID {
+		if access.Team.Name == teamName {
 			teamAccessID = access.ID
 		}
 	}
 
 	if teamAccessID == "" {
-		githubactions.Infof("Team access %q for workspace %q not found, skipping import\n", teamID, workspace)
+		githubactions.Infof("Team access %q for workspace %q not found, skipping import\n", teamName, workspace)
 		return nil
 	}
 

--- a/internal/action/import.go
+++ b/internal/action/import.go
@@ -155,6 +155,7 @@ func ImportVariable(ctx context.Context, tf TerraformCLI, client *tfe.Client, ke
 	return nil
 }
 
+// GetTeam returns a Team object if a team matching the passed name is found in the target Terraform account, nil is returned if the team is not found
 func GetTeam(ctx context.Context, client *tfe.Client, teamName string, organization string) (*tfe.Team, error) {
 	teams, err := client.Teams.List(ctx, organization, tfe.TeamListOptions{
 		ListOptions: tfe.ListOptions{

--- a/internal/action/import_test.go
+++ b/internal/action/import_test.go
@@ -477,7 +477,7 @@ var teamAccessAPIResponse = `{
             "type": "workspaces"
           },
           "links": {
-            "related": "/api/v2/organizations/takescoop/workspaces/ws"
+            "related": "/api/v2/organizations/org/workspaces/ws"
           }
         }
       },
@@ -546,7 +546,7 @@ var teamAPIResponse = `{
         }
       },
       "links": {
-        "self": "/api/v2/teams/team-SPVoAKkSVAq1XdvQ"
+        "self": "/api/v2/teams/team-abc123"
       }
     }
   ],

--- a/internal/action/import_test.go
+++ b/internal/action/import_test.go
@@ -198,8 +198,8 @@ func TestImportTeamAccess(t *testing.T) {
 			server.Close()
 		})
 
-		mux.HandleFunc("/api/v2/organizations/org/workspaces/ws", testServerResHandler(t, 200, wsAPIResponse))
 		mux.HandleFunc("/api/v2/organizations/org/teams", testServerResHandler(t, 200, teamAPIResponse))
+		mux.HandleFunc("/api/v2/organizations/org/workspaces/ws", testServerResHandler(t, 200, wsAPIResponse))
 		mux.HandleFunc("/api/v2/team-workspaces", testServerResHandler(t, 200, teamAccessAPIResponse))
 
 		client := newTestTFClient(t, server.URL)
@@ -222,7 +222,7 @@ func TestImportTeamAccess(t *testing.T) {
 
 		assert.Equal(t, len(tf.ImportArgs), 1)
 		assert.Equal(t, tf.ImportArgs[0], &ImportArgs{
-			Address: "tfe_team_access.teams[\"ws-Readers\"]",
+			Address: "tfe_team_access.teams[\"ws-team-abc123\"]",
 			ID:      "org/ws/tws-abc213",
 			Opts:    ([]tfexec.ImportOption)(nil),
 		})
@@ -236,6 +236,7 @@ func TestImportTeamAccess(t *testing.T) {
 			server.Close()
 		})
 
+		mux.HandleFunc("/api/v2/organizations/org/teams", testServerResHandler(t, 200, teamAPIResponse))
 		mux.HandleFunc("/api/v2/organizations/org/workspaces/ws", testServerResHandler(t, 404, `{}`))
 
 		client := newTestTFClient(t, server.URL)
@@ -259,7 +260,8 @@ func TestImportTeamAccess(t *testing.T) {
 			server.Close()
 		})
 
-		mux.HandleFunc("/api/v2/organizations/org/workspaces/ws", testServerResHandler(t, 404, `{}`))
+		mux.HandleFunc("/api/v2/organizations/org/teams", testServerResHandler(t, 200, teamAPIResponse))
+		mux.HandleFunc("/api/v2/organizations/org/workspaces/ws", testServerResHandler(t, 200, wsAPIResponse))
 
 		client := newTestTFClient(t, server.URL)
 
@@ -269,7 +271,7 @@ func TestImportTeamAccess(t *testing.T) {
 					RootModule: &tfjson.StateModule{
 						Resources: []*tfjson.StateResource{
 							{Address: "tfe_workspace.workspace[\"ws\"]"},
-							{Address: "tfe_team_access.teams[\"ws-Readers\"]"},
+							{Address: "tfe_team_access.teams[\"ws-team-abc123\"]"},
 						},
 					},
 				},
@@ -291,8 +293,8 @@ func TestImportTeamAccess(t *testing.T) {
 			server.Close()
 		})
 
-		mux.HandleFunc("/api/v2/organizations/org/workspaces/ws", testServerResHandler(t, 200, wsAPIResponse))
 		mux.HandleFunc("/api/v2/organizations/org/teams", testServerResHandler(t, 200, teamAPIResponse))
+		mux.HandleFunc("/api/v2/organizations/org/workspaces/ws", testServerResHandler(t, 200, wsAPIResponse))
 		mux.HandleFunc("/api/v2/team-workspaces", testServerResHandler(t, 200, `{"data": []}`))
 
 		client := newTestTFClient(t, server.URL)

--- a/internal/action/import_test.go
+++ b/internal/action/import_test.go
@@ -199,7 +199,8 @@ func TestImportTeamAccess(t *testing.T) {
 		})
 
 		mux.HandleFunc("/api/v2/organizations/org/workspaces/ws", testServerResHandler(t, 200, wsAPIResponse))
-		mux.HandleFunc("/api/v2/team-workspaces", testServerResHandler(t, 200, wsAPIResponse))
+		mux.HandleFunc("/api/v2/organizations/org/teams", testServerResHandler(t, 200, teamAPIResponse))
+		mux.HandleFunc("/api/v2/team-workspaces", testServerResHandler(t, 200, teamAccessAPIResponse))
 
 		client := newTestTFClient(t, server.URL)
 
@@ -215,13 +216,13 @@ func TestImportTeamAccess(t *testing.T) {
 			},
 		}
 
-		if err := ImportTeamAccess(ctx, &tf, client, "org", "ws", "team-abc123"); err != nil {
+		if err := ImportTeamAccess(ctx, &tf, client, "org", "ws", "Readers"); err != nil {
 			t.Fatal(err)
 		}
 
 		assert.Equal(t, len(tf.ImportArgs), 1)
 		assert.Equal(t, tf.ImportArgs[0], &ImportArgs{
-			Address: "tfe_team_access.teams[\"ws-team-abc123\"]",
+			Address: "tfe_team_access.teams[\"ws-Readers\"]",
 			ID:      "org/ws/tws-abc213",
 			Opts:    ([]tfexec.ImportOption)(nil),
 		})
@@ -243,7 +244,7 @@ func TestImportTeamAccess(t *testing.T) {
 			State: &tfjson.State{},
 		}
 
-		if err := ImportTeamAccess(ctx, &tf, client, "org", "ws", "team-abc123"); err != nil {
+		if err := ImportTeamAccess(ctx, &tf, client, "org", "ws", "Readers"); err != nil {
 			t.Fatal(err)
 		}
 
@@ -268,14 +269,14 @@ func TestImportTeamAccess(t *testing.T) {
 					RootModule: &tfjson.StateModule{
 						Resources: []*tfjson.StateResource{
 							{Address: "tfe_workspace.workspace[\"ws\"]"},
-							{Address: "tfe_team_access.teams[\"ws-team-abc123\"]"},
+							{Address: "tfe_team_access.teams[\"ws-Readers\"]"},
 						},
 					},
 				},
 			},
 		}
 
-		if err := ImportTeamAccess(ctx, &tf, client, "org", "ws", "team-abc123"); err != nil {
+		if err := ImportTeamAccess(ctx, &tf, client, "org", "ws", "Readers"); err != nil {
 			t.Fatal(err)
 		}
 
@@ -291,6 +292,7 @@ func TestImportTeamAccess(t *testing.T) {
 		})
 
 		mux.HandleFunc("/api/v2/organizations/org/workspaces/ws", testServerResHandler(t, 200, wsAPIResponse))
+		mux.HandleFunc("/api/v2/organizations/org/teams", testServerResHandler(t, 200, teamAPIResponse))
 		mux.HandleFunc("/api/v2/team-workspaces", testServerResHandler(t, 200, `{"data": []}`))
 
 		client := newTestTFClient(t, server.URL)
@@ -307,7 +309,7 @@ func TestImportTeamAccess(t *testing.T) {
 			},
 		}
 
-		if err := ImportTeamAccess(ctx, &tf, client, "org", "ws", "team-abc123"); err != nil {
+		if err := ImportTeamAccess(ctx, &tf, client, "org", "ws", "Readers"); err != nil {
 			t.Fatal(err)
 		}
 
@@ -442,4 +444,125 @@ var varsAPIResponse = `{
       }
     }
   ]
+}`
+
+var teamAccessAPIResponse = `{
+  "data": [
+    {
+      "id": "tws-abc213",
+      "type": "team-workspaces",
+      "attributes": {
+        "access": "write",
+        "runs": "apply",
+        "variables": "write",
+        "state-versions": "write",
+        "sentinel-mocks": "read",
+        "workspace-locking": true
+      },
+      "relationships": {
+        "team": {
+          "data": {
+            "id": "team-abc123",
+            "type": "teams"
+          },
+          "links": {
+            "related": "/api/v2/teams/team-abc123"
+          }
+        },
+        "workspace": {
+          "data": {
+            "id": "ws-abc123",
+            "type": "workspaces"
+          },
+          "links": {
+            "related": "/api/v2/organizations/takescoop/workspaces/ws"
+          }
+        }
+      },
+      "links": {
+        "self": "/api/v2/team-workspaces/tws-abc123"
+      }
+    }
+  ],
+  "links": {
+    "self": "https://app.terraform.io/api/v2/team-workspaces?filter%5Bworkspace%5D%5Bid%5D=ws-abc123\u0026page%5Bnumber%5D=1\u0026page%5Bsize%5D=100",
+    "first": "https://app.terraform.io/api/v2/team-workspaces?filter%5Bworkspace%5D%5Bid%5D=ws-abc123\u0026page%5Bnumber%5D=1\u0026page%5Bsize%5D=100",
+    "prev": null,
+    "next": null,
+    "last": "https://app.terraform.io/api/v2/team-workspaces?filter%5Bworkspace%5D%5Bid%5D=ws-abc123\u0026page%5Bnumber%5D=1\u0026page%5Bsize%5D=100"
+  },
+  "meta": {
+    "pagination": {
+      "current-page": 1,
+      "page-size": 100,
+      "prev-page": null,
+      "next-page": null,
+      "total-pages": 1,
+      "total-count": 1
+    }
+  }
+}`
+
+var teamAPIResponse = `{
+  "data": [
+    {
+      "id": "team-abc123",
+      "type": "teams",
+      "attributes": {
+        "name": "Readers",
+        "users-count": 0,
+        "visibility": "organization",
+        "permissions": {
+          "can-update-membership": true,
+          "can-destroy": true,
+          "can-update-organization-access": true,
+          "can-update-api-token": true,
+          "can-update-visibility": true
+        },
+        "organization-access": {
+          "manage-policies": false,
+          "manage-workspaces": false,
+          "manage-vcs-settings": false,
+          "manage-policy-overrides": false
+        }
+      },
+      "relationships": {
+        "organization": {
+          "data": {
+            "id": "org",
+            "type": "organizations"
+          }
+        },
+        "users": {
+          "data": []
+        },
+        "organization-memberships": {
+          "data": []
+        },
+        "authentication-token": {
+          "meta": {}
+        }
+      },
+      "links": {
+        "self": "/api/v2/teams/team-SPVoAKkSVAq1XdvQ"
+      }
+    }
+  ],
+  "links": {
+    "self": "https://app.terraform.io/api/v2/organizations/org/teams?page%5Bnumber%5D=1\u0026page%5Bsize%5D=100",
+    "first": "https://app.terraform.io/api/v2/organizations/org/teams?page%5Bnumber%5D=1\u0026page%5Bsize%5D=100",
+    "prev": null,
+    "next": null,
+    "last": "https://app.terraform.io/api/v2/organizations/org/teams?page%5Bnumber%5D=1\u0026page%5Bsize%5D=100"
+  },
+  "meta": {
+    "pagination": {
+      "current-page": 1,
+      "page-size": 100,
+      "prev-page": null,
+      "next-page": null,
+      "total-pages": 1,
+      "total-count": 1
+    }
+  }
 }`

--- a/internal/action/main.go
+++ b/internal/action/main.go
@@ -134,12 +134,6 @@ func Run() {
 		githubactions.Fatalf("Failed to parse teams: %s", err)
 	}
 
-	for _, teamInput := range teamInputs {
-		if err := teamInput.Validate(); err != nil {
-			githubactions.Fatalf("Failed to validate team access input: %s", err)
-		}
-	}
-
 	teamAccess := NewTeamAccess(teamInputs, workspaces)
 
 	backend, err := tfconfig.ParseBackend(githubactions.GetInput("backend_config"))
@@ -216,7 +210,7 @@ func Run() {
 		}
 
 		for _, access := range teamAccess {
-			if err = ImportTeamAccess(ctx, tf, client, org, access.Workspace.Name, access.TeamID); err != nil {
+			if err = ImportTeamAccess(ctx, tf, client, org, access.Workspace.Name, access.TeamName); err != nil {
 				githubactions.Fatalf("Failed to import team access: %s", err)
 			}
 		}

--- a/internal/action/team_access.go
+++ b/internal/action/team_access.go
@@ -1,8 +1,6 @@
 package action
 
 import (
-	"fmt"
-
 	"github.com/takescoop/terraform-cloud-workspace-action/internal/tfeprovider"
 )
 
@@ -14,7 +12,6 @@ type TeamAccessInputItem struct {
 	Access      string                      `yaml:"access,omitempty"`
 	Permissions *TeamAccessPermissionsInput `yaml:"permissions,omitempty"`
 	TeamName    string                      `yaml:"name"`
-	TeamID      string                      `yaml:"id"`
 }
 
 type TeamAccess []TeamAccessItem
@@ -23,7 +20,6 @@ type TeamAccessItem struct {
 	Access      string
 	Permissions *TeamAccessPermissionsInput
 	TeamName    string
-	TeamID      string
 
 	Workspace *Workspace
 }
@@ -40,7 +36,6 @@ func NewTeamAccess(inputs TeamAccessInput, workspaces []*Workspace) TeamAccess {
 				Access:      team.Access,
 				Permissions: team.Permissions,
 				TeamName:    team.TeamName,
-				TeamID:      team.TeamID,
 				Workspace:   ws,
 			}
 			i = i + 1
@@ -54,7 +49,6 @@ func NewTeamAccess(inputs TeamAccessInput, workspaces []*Workspace) TeamAccess {
 func (ta TeamAccessItem) ToResource() *tfeprovider.TeamAccess {
 	resource := &tfeprovider.TeamAccess{
 		Access: ta.Access,
-		TeamID: ta.TeamID,
 	}
 
 	if ta.Permissions != nil {
@@ -68,15 +62,6 @@ func (ta TeamAccessItem) ToResource() *tfeprovider.TeamAccess {
 	}
 
 	return resource
-}
-
-// Validate validates the content of the team access input
-func (tai TeamAccessInputItem) Validate() error {
-	if tai.TeamID != "" && tai.TeamName != "" {
-		return fmt.Errorf("team name and team ID cannot both be set: %s, %s", tai.TeamID, tai.TeamName)
-	}
-
-	return nil
 }
 
 type TeamAccessPermissionsInput struct {

--- a/internal/action/team_access_test.go
+++ b/internal/action/team_access_test.go
@@ -6,23 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestTeamAccessValidate(t *testing.T) {
-	t.Run("valid with team name", func(t *testing.T) {
-		access := TeamAccessInputItem{TeamName: "foo"}
-		assert.NoError(t, access.Validate())
-	})
-
-	t.Run("valid with team ID", func(t *testing.T) {
-		access := TeamAccessInputItem{TeamID: "team-abc123"}
-		assert.NoError(t, access.Validate())
-	})
-
-	t.Run("not valid with team ID and team name", func(t *testing.T) {
-		access := TeamAccessInputItem{TeamName: "foo", TeamID: "team-abc123"}
-		assert.Error(t, access.Validate())
-	})
-}
-
 type NewTeamAccessTestCase struct {
 	Description string
 	Workspaces  []*Workspace

--- a/internal/action/workspace.go
+++ b/internal/action/workspace.go
@@ -157,18 +157,15 @@ func AppendTeamAccess(module *tfconfig.Module, teamAccess TeamAccess, organizati
 	resourceForEach := map[string]tfeprovider.TeamAccess{}
 
 	for _, access := range teamAccess {
-		teamIDRef := access.TeamID
 
-		if teamIDRef == "" {
-			dataForEach[access.TeamName] = TeamDataResource{
-				Name:         access.TeamName,
-				Organization: organization,
-			}
-
-			teamIDRef = fmt.Sprintf("${data.tfe_team.teams[\"%s\"].id}", access.TeamName)
+		dataForEach[access.TeamName] = TeamDataResource{
+			Name:         access.TeamName,
+			Organization: organization,
 		}
 
-		resourceForEach[fmt.Sprintf("%s-%s", access.Workspace.Name, teamIDRef)] = tfeprovider.TeamAccess{
+		teamIDRef := fmt.Sprintf("${data.tfe_team.teams[\"%s\"].id}", access.TeamName)
+
+		resourceForEach[fmt.Sprintf("%s-%s", access.Workspace.Name, access.TeamName)] = tfeprovider.TeamAccess{
 			TeamID:      teamIDRef,
 			WorkspaceID: fmt.Sprintf("${tfe_workspace.workspace[%q].id}", access.Workspace.Name),
 			Access:      access.Access,

--- a/internal/action/workspace.go
+++ b/internal/action/workspace.go
@@ -172,13 +172,11 @@ func AppendTeamAccess(module *tfconfig.Module, teamAccess TeamAccess, organizati
 		}
 	}
 
-	if len(dataForEach) > 0 {
-		module.AppendData("tfe_team", "teams", TeamDataResource{
-			ForEach:      dataForEach,
-			Name:         "${each.value.name}",
-			Organization: "${each.value.organization}",
-		})
-	}
+	module.AppendData("tfe_team", "teams", TeamDataResource{
+		ForEach:      dataForEach,
+		Name:         "${each.value.name}",
+		Organization: "${each.value.organization}",
+	})
 
 	module.AppendResource("tfe_team_access", "teams", tfeprovider.TeamAccess{
 		ForEach:     resourceForEach,

--- a/internal/action/workspace.go
+++ b/internal/action/workspace.go
@@ -164,7 +164,7 @@ func AppendTeamAccess(module *tfconfig.Module, teamAccess TeamAccess, organizati
 
 		teamIDRef := fmt.Sprintf("${data.tfe_team.teams[\"%s\"].id}", access.TeamName)
 
-		resourceForEach[fmt.Sprintf("%s-%s", access.Workspace.Name, access.TeamName)] = tfeprovider.TeamAccess{
+		resourceForEach[fmt.Sprintf("%s-%s", access.Workspace.Name, teamIDRef)] = tfeprovider.TeamAccess{
 			TeamID:      teamIDRef,
 			WorkspaceID: fmt.Sprintf("${tfe_workspace.workspace[%q].id}", access.Workspace.Name),
 			Access:      access.Access,

--- a/internal/action/workspace.go
+++ b/internal/action/workspace.go
@@ -157,7 +157,6 @@ func AppendTeamAccess(module *tfconfig.Module, teamAccess TeamAccess, organizati
 	resourceForEach := map[string]tfeprovider.TeamAccess{}
 
 	for _, access := range teamAccess {
-
 		dataForEach[access.TeamName] = TeamDataResource{
 			Name:         access.TeamName,
 			Organization: organization,

--- a/internal/action/workspace_test.go
+++ b/internal/action/workspace_test.go
@@ -338,12 +338,12 @@ func TestAppendTeamAccess(t *testing.T) {
 
 		assert.Equal(t, module.Resources["tfe_team_access"]["teams"], tfeprovider.TeamAccess{
 			ForEach: map[string]tfeprovider.TeamAccess{
-				"workspace-${data.tfe_team.teams[\"Writers\"].id}": {
+				"workspace-Writers": {
 					TeamID:      "${data.tfe_team.teams[\"Writers\"].id}",
 					WorkspaceID: "${tfe_workspace.workspace[\"workspace\"].id}",
 					Access:      "write",
 				},
-				"workspace-${data.tfe_team.teams[\"Readers\"].id}": {
+				"workspace-Readers": {
 					TeamID:      "${data.tfe_team.teams[\"Readers\"].id}",
 					WorkspaceID: "${tfe_workspace.workspace[\"workspace\"].id}",
 					Access:      "read",
@@ -363,89 +363,6 @@ func TestAppendTeamAccess(t *testing.T) {
 						WorkspaceLocking: "${each.value.permissions.workspace_locking}",
 					},
 				}},
-			},
-		})
-	})
-
-	t.Run("Add team access with a team ID", func(t *testing.T) {
-		module := &tfconfig.Module{
-			Data:      map[string]map[string]interface{}{},
-			Resources: map[string]map[string]interface{}{},
-		}
-
-		AppendTeamAccess(module, TeamAccess{
-			TeamAccessItem{TeamName: "Writers", Access: "write", Workspace: &Workspace{Name: "workspace"}},
-			TeamAccessItem{TeamID: "team-12345", Access: "read", Workspace: &Workspace{Name: "workspace"}},
-		}, "org")
-
-		assert.Equal(t, module.Data["tfe_team"]["teams"].(TeamDataResource).ForEach, map[string]TeamDataResource{
-			"Writers": {
-				Name:         "Writers",
-				Organization: "org",
-			},
-		})
-
-		assert.Equal(t, module.Resources["tfe_team_access"]["teams"].(tfeprovider.TeamAccess).ForEach, map[string]tfeprovider.TeamAccess{
-			"workspace-${data.tfe_team.teams[\"Writers\"].id}": {
-				TeamID:      "${data.tfe_team.teams[\"Writers\"].id}",
-				WorkspaceID: "${tfe_workspace.workspace[\"workspace\"].id}",
-				Access:      "write",
-			},
-			"workspace-team-12345": {
-				TeamID:      "team-12345",
-				WorkspaceID: "${tfe_workspace.workspace[\"workspace\"].id}",
-				Access:      "read",
-			},
-		})
-	})
-
-	t.Run("Add only team access items containing team IDs", func(t *testing.T) {
-		module := &tfconfig.Module{
-			Data:      map[string]map[string]interface{}{},
-			Resources: map[string]map[string]interface{}{},
-		}
-
-		AppendTeamAccess(module, TeamAccess{
-			TeamAccessItem{TeamID: "team-12345", Access: "write", Workspace: &Workspace{Name: "workspace"}},
-			TeamAccessItem{TeamID: "team-67890", Access: "read", Workspace: &Workspace{Name: "workspace"}},
-		}, "org")
-
-		assert.Equal(t, module.Data["tfe_team"]["teams"], nil)
-
-		assert.Equal(t, module.Resources["tfe_team_access"]["teams"].(tfeprovider.TeamAccess).ForEach, map[string]tfeprovider.TeamAccess{
-			"workspace-team-12345": {
-				TeamID:      "team-12345",
-				WorkspaceID: "${tfe_workspace.workspace[\"workspace\"].id}",
-				Access:      "write",
-			},
-			"workspace-team-67890": {
-				TeamID:      "team-67890",
-				WorkspaceID: "${tfe_workspace.workspace[\"workspace\"].id}",
-				Access:      "read",
-			},
-		})
-	})
-
-	t.Run("Add with team ID expression", func(t *testing.T) {
-		module := &tfconfig.Module{
-			Data:      map[string]map[string]interface{}{},
-			Resources: map[string]map[string]interface{}{},
-		}
-
-		AppendTeamAccess(module, TeamAccess{
-			TeamAccessItem{
-				TeamID:    "${data.terraform_remote_state.teams.output.teams[\"team\"].id}",
-				Access:    "write",
-				Workspace: &Workspace{Name: "workspace"}},
-		}, "org")
-
-		assert.Equal(t, module.Data["tfe_team"]["teams"], nil)
-
-		assert.Equal(t, module.Resources["tfe_team_access"]["teams"].(tfeprovider.TeamAccess).ForEach, map[string]tfeprovider.TeamAccess{
-			"workspace-${data.terraform_remote_state.teams.output.teams[\"team\"].id}": {
-				TeamID:      "${data.terraform_remote_state.teams.output.teams[\"team\"].id}",
-				WorkspaceID: "${tfe_workspace.workspace[\"workspace\"].id}",
-				Access:      "write",
 			},
 		})
 	})
@@ -474,7 +391,7 @@ func TestAppendTeamAccess(t *testing.T) {
 		})
 
 		assert.Equal(t, module.Resources["tfe_team_access"]["teams"].(tfeprovider.TeamAccess).ForEach, map[string]tfeprovider.TeamAccess{
-			"workspace-${data.tfe_team.teams[\"Readers\"].id}": {
+			"workspace-Readers": {
 				TeamID:      "${data.tfe_team.teams[\"Readers\"].id}",
 				WorkspaceID: "${tfe_workspace.workspace[\"workspace\"].id}",
 				Access:      "",

--- a/internal/action/workspace_test.go
+++ b/internal/action/workspace_test.go
@@ -338,12 +338,12 @@ func TestAppendTeamAccess(t *testing.T) {
 
 		assert.Equal(t, module.Resources["tfe_team_access"]["teams"], tfeprovider.TeamAccess{
 			ForEach: map[string]tfeprovider.TeamAccess{
-				"workspace-Writers": {
+				"workspace-${data.tfe_team.teams[\"Writers\"].id}": {
 					TeamID:      "${data.tfe_team.teams[\"Writers\"].id}",
 					WorkspaceID: "${tfe_workspace.workspace[\"workspace\"].id}",
 					Access:      "write",
 				},
-				"workspace-Readers": {
+				"workspace-${data.tfe_team.teams[\"Readers\"].id}": {
 					TeamID:      "${data.tfe_team.teams[\"Readers\"].id}",
 					WorkspaceID: "${tfe_workspace.workspace[\"workspace\"].id}",
 					Access:      "read",
@@ -391,7 +391,7 @@ func TestAppendTeamAccess(t *testing.T) {
 		})
 
 		assert.Equal(t, module.Resources["tfe_team_access"]["teams"].(tfeprovider.TeamAccess).ForEach, map[string]tfeprovider.TeamAccess{
-			"workspace-Readers": {
+			"workspace-${data.tfe_team.teams[\"Readers\"].id}": {
 				TeamID:      "${data.tfe_team.teams[\"Readers\"].id}",
 				WorkspaceID: "${tfe_workspace.workspace[\"workspace\"].id}",
 				Access:      "",


### PR DESCRIPTION
Forces use of a team name to identify a team for team access and removes the ability to pass a team ID. 

Also updates the readme to display remote states as a sub feature to variables, rather than something widely supported by the project