### PR TITLE
Add missing workspace directory input

### DIFF
--- a/internal/action/main.go
+++ b/internal/action/main.go
@@ -159,6 +159,7 @@ func Run() {
 			VCSRepo:                githubactions.GetInput("vcs_repo"),
 			VCSTokenID:             githubactions.GetInput("vcs_token_id"),
 			VCSType:                githubactions.GetInput("vcs_type"),
+			WorkingDirectory:       githubactions.GetInput("working_directory"),
 		},
 		RemoteStates: remoteStates,
 		Variables:    variables,


### PR DESCRIPTION
Somewhere along the line, `working_directory` was removed as an input to the workspace configuration (or maybe it never was). Change here ensures that `working_directory` is passed