### PR TITLE
Fix workspaces parse

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -87,8 +87,5 @@ outputs:
   plan_json:
     description: A JSON representation of the Terraform plan.
 runs:
-  using: composite
-  steps:
-    - uses: hashicorp/setup-terraform@v1
-    - using: docker
-      image: Dockerfile
+  using: docker
+  image: Dockerfile

--- a/action.yml
+++ b/action.yml
@@ -87,5 +87,8 @@ outputs:
   plan_json:
     description: A JSON representation of the Terraform plan.
 runs:
-  using: docker
-  image: Dockerfile
+  using: composite
+  steps:
+    - uses: hashicorp/setup-terraform@v1
+    - using: docker
+      image: Dockerfile

--- a/internal/action/main.go
+++ b/internal/action/main.go
@@ -67,9 +67,15 @@ func Run() {
 		githubactions.Fatalf("Failed to parse remote state blocks: %s", err)
 	}
 
-	workspaces, err := ParseWorkspaceYAML(githubactions.GetInput("workspaces"), name)
+	var wsInputs []string
+	err = yaml.Unmarshal([]byte(githubactions.GetInput("workspaces")), &wsInputs)
 	if err != nil {
-		githubactions.Fatalf("Failed to parse workspacess: %s", err)
+		githubactions.Fatalf("Failed to decode workspaces: %s", err)
+	}
+
+	workspaces, err := ParseWorkspaces(wsInputs, name)
+	if err != nil {
+		githubactions.Fatalf("Failed to parse workspaces: %s", err)
 	}
 
 	genVars := VariablesInput{}

--- a/internal/action/main.go
+++ b/internal/action/main.go
@@ -67,26 +67,9 @@ func Run() {
 		githubactions.Fatalf("Failed to parse remote state blocks: %s", err)
 	}
 
-	var workspaces []*Workspace
-
-	if githubactions.GetInput("workspaces") == "" {
-		workspaces = append(workspaces, &Workspace{
-			Name:      name,
-			Workspace: "default",
-		})
-	} else {
-		var wsNames []string
-
-		if err = yaml.Unmarshal([]byte(githubactions.GetInput("workspaces")), wsNames); err != nil {
-			githubactions.Fatalf("Failed to parse workspaces: %s", err)
-		}
-
-		for _, wsn := range wsNames {
-			workspaces = append(workspaces, &Workspace{
-				Name:      fmt.Sprintf("%s-%s", name, wsn),
-				Workspace: wsn,
-			})
-		}
+	workspaces, err := ParseWorkspaceYAML(githubactions.GetInput("workspaces"), name)
+	if err != nil {
+		githubactions.Fatalf("Failed to parse workspacess: %s", err)
 	}
 
 	genVars := VariablesInput{}

--- a/internal/action/main.go
+++ b/internal/action/main.go
@@ -68,6 +68,7 @@ func Run() {
 	}
 
 	var wsInputs []string
+
 	err = yaml.Unmarshal([]byte(githubactions.GetInput("workspaces")), &wsInputs)
 	if err != nil {
 		githubactions.Fatalf("Failed to decode workspaces: %s", err)

--- a/internal/action/workspace.go
+++ b/internal/action/workspace.go
@@ -9,6 +9,7 @@ import (
 	tfjson "github.com/hashicorp/terraform-json"
 	"github.com/takescoop/terraform-cloud-workspace-action/internal/tfconfig"
 	"github.com/takescoop/terraform-cloud-workspace-action/internal/tfeprovider"
+	yaml "gopkg.in/yaml.v2"
 )
 
 type Workspace struct {
@@ -289,4 +290,31 @@ func FindWorkspace(workspaces []*Workspace, target string) *Workspace {
 	}
 
 	return nil
+}
+
+// ParseWorkspaceYAML takes list of YAML encoded workspaces and the generic workspace name, and returns a list of Workspace objects
+func ParseWorkspaceYAML(input string, name string) ([]*Workspace, error) {
+	var workspaces []*Workspace
+
+	if input == "" {
+		workspaces = append(workspaces, &Workspace{
+			Name:      name,
+			Workspace: "default",
+		})
+	} else {
+		var wsNames []string
+
+		if err := yaml.Unmarshal([]byte(input), &wsNames); err != nil {
+			return nil, err
+		}
+
+		for _, wsn := range wsNames {
+			workspaces = append(workspaces, &Workspace{
+				Name:      fmt.Sprintf("%s-%s", name, wsn),
+				Workspace: wsn,
+			})
+		}
+	}
+
+	return workspaces, nil
 }

--- a/internal/action/workspace.go
+++ b/internal/action/workspace.go
@@ -9,7 +9,6 @@ import (
 	tfjson "github.com/hashicorp/terraform-json"
 	"github.com/takescoop/terraform-cloud-workspace-action/internal/tfconfig"
 	"github.com/takescoop/terraform-cloud-workspace-action/internal/tfeprovider"
-	yaml "gopkg.in/yaml.v2"
 )
 
 type Workspace struct {
@@ -292,23 +291,17 @@ func FindWorkspace(workspaces []*Workspace, target string) *Workspace {
 	return nil
 }
 
-// ParseWorkspaceYAML takes list of YAML encoded workspaces and the generic workspace name, and returns a list of Workspace objects
-func ParseWorkspaceYAML(input string, name string) ([]*Workspace, error) {
+// ParseWorkspaces takes list of YAML encoded workspaces and the generic workspace name, and returns a list of Workspace objects
+func ParseWorkspaces(workspaceNames []string, name string) ([]*Workspace, error) {
 	var workspaces []*Workspace
 
-	if input == "" {
+	if len(workspaceNames) == 0 {
 		workspaces = append(workspaces, &Workspace{
 			Name:      name,
 			Workspace: "default",
 		})
 	} else {
-		var wsNames []string
-
-		if err := yaml.Unmarshal([]byte(input), &wsNames); err != nil {
-			return nil, err
-		}
-
-		for _, wsn := range wsNames {
+		for _, wsn := range workspaceNames {
 			workspaces = append(workspaces, &Workspace{
 				Name:      fmt.Sprintf("%s-%s", name, wsn),
 				Workspace: wsn,

--- a/internal/action/workspace.go
+++ b/internal/action/workspace.go
@@ -291,7 +291,7 @@ func FindWorkspace(workspaces []*Workspace, target string) *Workspace {
 	return nil
 }
 
-// ParseWorkspaces takes list of YAML encoded workspaces and the generic workspace name, and returns a list of Workspace objects
+// ParseWorkspaces a list of workspace names and the generic workspace name and returns a list of Workspace objects. "default" is used if no workspace names are passed.
 func ParseWorkspaces(workspaceNames []string, name string) ([]*Workspace, error) {
 	var workspaces []*Workspace
 

--- a/internal/action/workspace_test.go
+++ b/internal/action/workspace_test.go
@@ -859,9 +859,9 @@ func TestFindWorkspace(t *testing.T) {
 	})
 }
 
-func TestParseWorkspaceYAML(t *testing.T) {
+func TestParseWorkspaces(t *testing.T) {
 	t.Run("single workspace", func(t *testing.T) {
-		workspaces, err := ParseWorkspaceYAML("", "foo")
+		workspaces, err := ParseWorkspaces([]string{}, "foo")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -874,10 +874,7 @@ func TestParseWorkspaceYAML(t *testing.T) {
 	})
 
 	t.Run("Multiple workspaces", func(t *testing.T) {
-		workspaces, err := ParseWorkspaceYAML(`---
-- staging		
-- production
-`, "foo")
+		workspaces, err := ParseWorkspaces([]string{"staging", "production"}, "foo")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/action/workspace_test.go
+++ b/internal/action/workspace_test.go
@@ -858,3 +858,38 @@ func TestFindWorkspace(t *testing.T) {
 		}, "foo"), (*Workspace)(nil))
 	})
 }
+
+func TestParseWorkspaceYAML(t *testing.T) {
+	t.Run("single workspace", func(t *testing.T) {
+		workspaces, err := ParseWorkspaceYAML("", "foo")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Equal(t, len(workspaces), 1)
+		assert.Equal(t, workspaces[0], &Workspace{
+			Name:      "foo",
+			Workspace: "default",
+		})
+	})
+
+	t.Run("Multiple workspaces", func(t *testing.T) {
+		workspaces, err := ParseWorkspaceYAML(`---
+- staging		
+- production
+`, "foo")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Equal(t, len(workspaces), 2)
+		assert.Equal(t, workspaces[0], &Workspace{
+			Name:      "foo-staging",
+			Workspace: "staging",
+		})
+		assert.Equal(t, workspaces[1], &Workspace{
+			Name:      "foo-production",
+			Workspace: "production",
+		})
+	})
+}


### PR DESCRIPTION
Testing out multiple workspaces for aws-golden-gate, [found a bug](https://github.com/TakeScoop/aws-golden-gate/runs/3498502240).


```diff
var wsNames []string
- yaml.Unmarshal([]byte(githubactions.getInput("workspaces")), wsNames)
+ yaml.Unmarshal([]byte(githubactions.getInput("workspaces")), &wsNames)
```
^^ this line should have dereferenced the variable so that a pointer was passed

I moved the logic to a function and added a test for both single and multi workspaces


