### PR TITLE
Remove default category from variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ with:
 
 ### Variables and Workspace Variables
 
-`variables` are applied to all created workspaces, where `workspace_variables` are applied to the noted workspace
+`variables` are applied to all created workspaces, where `workspace_variables` are applied to the noted workspace. Per the [workspace docs](https://www.terraform.io/docs/cloud/workspaces/variables.html), `category` field must be set to either `env` or `terraform`.
 
 ```yml
 ...
@@ -91,14 +91,17 @@ with:
   variables: |-
     - key: general-secret
       value: "${{ secrets.SECRET }}"
+      category: env
       sensitive: true
   workspace_variables: |-
     staging:
       - key: environment
         value: staging
+        category: terraform
     production:
       - key: environment
         value: production
+        category: terraform
 ```
 
 #### Remote state variable reference
@@ -111,8 +114,10 @@ with:
   variables: |-
     - key: s3_secret
       value: ${data.terraform_remote_state.workspace_s3.outputs.secret}
+      category: env
     - key: tf_cloud_secret
       value: ${data.terraform_remote_state.workspace_tf_cloud.outputs.secret}
+      category: env
   remote_states: |-
     workspace_s3:
       backend: remote

--- a/internal/action/variable.go
+++ b/internal/action/variable.go
@@ -43,7 +43,7 @@ func NewVariable(vi VariablesInputItem, w *Workspace) *Variable {
 
 // ToResource converts a variable to a Terraform variable resource
 func (v Variable) ToResource() *tfeprovider.Variable {
-	resource := &tfeprovider.Variable{
+	return &tfeprovider.Variable{
 		Key:         v.Key,
 		Value:       v.Value,
 		Description: v.Description,
@@ -51,12 +51,6 @@ func (v Variable) ToResource() *tfeprovider.Variable {
 		Sensitive:   v.Sensitive,
 		WorkspaceID: fmt.Sprintf("${tfe_workspace.workspace[%q].id}", v.Workspace.Name),
 	}
-
-	if resource.Category == "" {
-		resource.Category = "env"
-	}
-
-	return resource
 }
 
 // ToResource converts a list of variables to a list of Terraform variable resources


### PR DESCRIPTION
Removes the default "env" category from passed workspace variables. Neither of these really makes sense as the default, as they both have separate use cases. 