### PR TITLE
Use local backend on non-applies

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ jobs:
 | `execution_mode` | Execution mode to use for the workspace | |
 | `file_triggers_enabled` | Whether to filter runs based on the changed files in a VCS push | |
 | `global_remote_state` | Whether all workspaces in the organization can access the workspace via remote state | `false` |
-| `import` | Whether to import existing matching resources from the Terraform Cloud organization | `true` |
+| `import` | Whether to import existing matching resources from the Terraform Cloud organization. Ran as a dry run if `apply` is false. | `true` |
 | `name` | Name of the workspace. Becomes a prefix if workspaces are passed (`${name}-${workspace}`) | `"${{ github.event.repository.name }}" `|
 | `queue_all_runs` | Whether the workspace should start automatically performing runs immediately after creation | |
 | `remote_state_consumer_ids` | Comma separated list of workspace IDs to allow read access to the workspace outputs | |

--- a/README.md
+++ b/README.md
@@ -154,7 +154,9 @@ with:
 
 ### Importing existing resources
 
-By default, the action will import existing resources of matching values within the Terraform Cloud organization. When `apply` is set to `false`, the configured backend state will be copied to a local backend and `import` will be set to `true`. This grants some visibility into the import changes before they are actually applied to the configured backend.
+By default, the action will import any existing resources it can find based on a unique attribute. It makes multiple passes to discover all existing resources, first finding matching workspaces and then related resources (variables, team access).
+
+When `apply` is set to `false`, the configured backend state will be copied to a local backend and `import` will be set to `true`. This grants some visibility into the import changes before they are actually applied to the configured backend.
 
 To disable the import feature, set `import` to `false`
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ jobs:
 | `execution_mode` | Execution mode to use for the workspace | |
 | `file_triggers_enabled` | Whether to filter runs based on the changed files in a VCS push | |
 | `global_remote_state` | Whether all workspaces in the organization can access the workspace via remote state | `false` |
-| `import` | Whether to attempt to import existing matching resources using the resource name | `false` |
+| `import` | Whether to import existing matching resources from the Terraform Cloud organization | `true` |
 | `name` | Name of the workspace. Becomes a prefix if workspaces are passed (`${name}-${workspace}`) | `"${{ github.event.repository.name }}" `|
 | `queue_all_runs` | Whether the workspace should start automatically performing runs immediately after creation | |
 | `remote_state_consumer_ids` | Comma separated list of workspace IDs to allow read access to the workspace outputs | |
@@ -63,7 +63,7 @@ jobs:
 This project supports any backend supported by the selected Terraform version. The backend is used to persist the state of the Terraform Cloud workspace itself and its related resources (e.g., variables, teams). You generally should not pass "remote" workspace configuration, since that creates a circular dependency. 
 
 If no backend is passed, the default Terraform local backend will be used.
-**NOTE** When using the default local backend, `import` will always be true to ensure that resources can be managed across action runs. 
+**NOTE** When using the default local backend, `import` should always be `true` to ensure that resources can be managed across action runs. 
 
 ```yml
 with:
@@ -154,12 +154,14 @@ with:
 
 ### Importing existing resources
 
-Set `import` to `true` for the action to attempt to import existing resources of matching values within the Terraform Cloud organization
+By default, the action will import existing resources of matching values within the Terraform Cloud organization. When `apply` is set to `false`, the configured backend state will be copied to a local backend and `import` will be set to `true`. This grants some visibility into the import changes before they are actually applied to the configured backend.
+
+To disable the import feature, set `import` to `false`
 
 ```yml
 ...
 with:
-  import: true
+  import: false
 ```
 
 ## Outputs

--- a/action.yml
+++ b/action.yml
@@ -31,8 +31,8 @@ inputs:
     description: Whether to apply the proposed Terraform changes.
     required: true
   import:
-    description: Whether to attempt to import existing matching resources using the resource name.
-    default: false
+    description: Whether to import existing matching resources from the Terraform Cloud organization.
+    default: true
   variables:
     description: YAML encoded variables to apply to all workspaces.
     default: ""

--- a/internal/action/main.go
+++ b/internal/action/main.go
@@ -259,6 +259,7 @@ func Run() {
 			if err = tf.Apply(ctx, tfexec.DirOrPlan(planPath)); err != nil {
 				githubactions.Fatalf("Failed to apply: %s", err)
 			}
+
 			githubactions.Infof("Success\n")
 		}
 	} else {

--- a/internal/action/main.go
+++ b/internal/action/main.go
@@ -178,7 +178,7 @@ func Run() {
 	}
 
 	if err = tf.Init(ctx); err != nil {
-		githubactions.Fatalf("Failed initialize the Terraform workspace: %s", err)
+		githubactions.Fatalf("Failed to initialize the Terraform workspace: %s", err)
 	}
 
 	if !apply {

--- a/internal/action/main.go
+++ b/internal/action/main.go
@@ -25,6 +25,7 @@ func Run() {
 	host := githubactions.GetInput("terraform_host")
 	name := strings.TrimSpace(githubactions.GetInput("name"))
 	org := githubactions.GetInput("terraform_organization")
+	apply := inputs.GetBool("apply")
 
 	client, err := tfe.NewClient(&tfe.Config{
 		Address: fmt.Sprintf("https://%s", host),
@@ -131,7 +132,7 @@ func Run() {
 		githubactions.Fatalf("Failed to parse backend configuration: %s", err)
 	}
 
-	wsConfig, err := NewWorkspaceConfig(ctx, client, workspaces, &NewWorkspaceConfigOptions{
+	module, err := NewWorkspaceConfig(ctx, client, workspaces, &NewWorkspaceConfigOptions{
 		Backend: backend,
 		WorkspaceResourceOptions: &WorkspaceResourceOptions{
 			AgentPoolID:            githubactions.GetInput("agent_pool_id"),
@@ -170,20 +171,29 @@ func Run() {
 		githubactions.Fatalf("Failed to create new workspace configuration: %s", err)
 	}
 
-	b, err = json.MarshalIndent(wsConfig, "", "\t")
-	if err != nil {
-		githubactions.Fatalf("Failed to marshal workspace configuration: %s", err)
-	}
+	filePath := path.Join(workDir, "main.tf.json")
 
-	if err = ioutil.WriteFile(path.Join(workDir, "main.tf.json"), b, 0644); err != nil {
-		githubactions.Fatalf("Failed to write configuration to working directory: %s", err)
+	if err = WriteModuleFile(module, filePath); err != nil {
+		githubactions.Fatalf("Failed to write the Terraform workspace configuration: %s", err)
 	}
 
 	if err = tf.Init(ctx); err != nil {
-		githubactions.Fatalf("Failed to run Init: %s", err)
+		githubactions.Fatalf("Failed initialize the Terraform workspace: %s", err)
 	}
 
-	if inputs.GetBool("import") || backend == nil {
+	if !apply {
+		module.Terraform.Backend = nil
+
+		if err = WriteModuleFile(module, filePath); err != nil {
+			githubactions.Fatalf("Failed to write the Terraform workspace with local backend configuration: %s", err)
+		}
+
+		if err = tf.Init(ctx); err != nil {
+			githubactions.Fatalf("Failed to initialize the Terraform workspace with local backend configuration: %s", err)
+		}
+	}
+
+	if inputs.GetBool("import") {
 		githubactions.Infof("Importing resources...\n")
 
 		for _, ws := range workspaces {
@@ -243,12 +253,13 @@ func Run() {
 			githubactions.Fatalf("Error: allow_workspace_deletion must be true to allow workspace deletion. Deleting a workspace will permanently, irrecoverably delete all of its stored Terraform state versions.")
 		}
 
-		if inputs.GetBool("apply") {
+		if apply {
 			githubactions.Infof("Applying...\n")
 
 			if err = tf.Apply(ctx, tfexec.DirOrPlan(planPath)); err != nil {
 				githubactions.Fatalf("Failed to apply: %s", err)
 			}
+			githubactions.Infof("Success\n")
 		}
 	} else {
 		githubactions.Infof("No changes")

--- a/internal/action/workspace.go
+++ b/internal/action/workspace.go
@@ -2,7 +2,9 @@ package action
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"strings"
 
 	tfe "github.com/hashicorp/go-tfe"
@@ -243,6 +245,20 @@ func NewWorkspaceConfig(ctx context.Context, client *tfe.Client, workspaces []*W
 	AddProviders(module, config.Providers)
 
 	return module, nil
+}
+
+// WriteModuleFile is a simple utility to marshal the passed module and write it to the passed file path
+func WriteModuleFile(module *tfconfig.Module, filePath string) error {
+	b, err := json.MarshalIndent(module, "", "\t")
+	if err != nil {
+		return err
+	}
+
+	if err = ioutil.WriteFile(filePath, b, 0644); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func AddProviders(module *tfconfig.Module, providers []Provider) {

--- a/internal/action/workspace.go
+++ b/internal/action/workspace.go
@@ -249,7 +249,7 @@ func NewWorkspaceConfig(ctx context.Context, client *tfe.Client, workspaces []*W
 
 // WriteModuleFile is a simple utility to marshal the passed module and write it to the passed file path
 func WriteModuleFile(module *tfconfig.Module, filePath string) error {
-	b, err := json.MarshalIndent(module, "", "\t")
+	b, err := json.MarshalIndent(module, "", "  ")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
To create an accurate plan that doesn't mutate any Terraform state, we can copy the configured backend to a local backend and then run our operations on it.

We can copy state to a local backend using tfexec's `Init()` once with the first backend and once after removing the backend. The [command is run](https://github.com/hashicorp/terraform-exec/blob/main/tfexec/init.go#L119) with force-copy and input=false, which is super convenient for us!

Changes:
- When `apply` is `false`, the default Terraform local backend will be used
- `import` is now defaulted to `true`. Since we're targeting a replica backend, we can import to our hearts content, just a bit slow. We should also ensure that the workflow only runs when the workspace action file is changed to ease the load on our Cloud API.
- Removed import = true when backend == nil. It feels weird not to allow the import feature to be disabled, as you will always have a `nil` backend if `apply` is `false`. Additionally with the import default being true, it  seems less important to auto-set import to true if the backend is `nil`.

