### PR TITLE
Set workspace ID once, lookup ID for subsequent actions

### DIFF
--- a/internal/action/import.go
+++ b/internal/action/import.go
@@ -36,6 +36,7 @@ type TerraformCLI interface {
 	Import(context.Context, string, string, ...tfexec.ImportOption) error
 }
 
+// ImportWorkspace imports the passed workspace into Terraform state
 func ImportWorkspace(ctx context.Context, tf TerraformCLI, client *tfe.Client, workspace *Workspace, organization string, opts ...tfexec.ImportOption) error {
 	if workspace.ID == nil {
 		githubactions.Infof("Workspace %q not found, skipping import\n", workspace.Name)
@@ -89,6 +90,7 @@ func fetchVariableByKey(ctx context.Context, client *tfe.Client, key string, wor
 	return nil, nil
 }
 
+// ImportVariable imports the passed variable into Terraform state
 func ImportVariable(ctx context.Context, tf TerraformCLI, client *tfe.Client, key string, workspace *Workspace, organization string, opts ...tfexec.ImportOption) error {
 	if workspace.ID == nil {
 		githubactions.Infof("Workspace %q not found, skipping import\n", workspace.Name)

--- a/internal/action/import.go
+++ b/internal/action/import.go
@@ -36,8 +36,13 @@ type TerraformCLI interface {
 	Import(context.Context, string, string, ...tfexec.ImportOption) error
 }
 
-func ImportWorkspace(ctx context.Context, tf TerraformCLI, client *tfe.Client, name string, organization string, opts ...tfexec.ImportOption) error {
-	address := fmt.Sprintf("tfe_workspace.workspace[%q]", name)
+func ImportWorkspace(ctx context.Context, tf TerraformCLI, client *tfe.Client, workspace *Workspace, organization string, opts ...tfexec.ImportOption) error {
+	if workspace.ID == nil {
+		githubactions.Infof("Workspace %q not found, skipping import\n", workspace.Name)
+		return nil
+	}
+
+	address := fmt.Sprintf("tfe_workspace.workspace[%q]", workspace.Name)
 
 	imp, err := shouldImport(ctx, tf, address)
 	if err != nil {
@@ -45,28 +50,18 @@ func ImportWorkspace(ctx context.Context, tf TerraformCLI, client *tfe.Client, n
 	}
 
 	if !imp {
-		githubactions.Infof("Workspace %q already exists in state, skipping import\n", name)
+		githubactions.Infof("Workspace %q already exists in state, skipping import\n", workspace.Name)
 		return nil
 	}
 
-	ws, err := GetWorkspace(ctx, client, organization, name)
+	githubactions.Infof("Importing workspace: %s\n", workspace.Name)
+
+	err = tf.Import(ctx, address, *workspace.ID, opts...)
 	if err != nil {
 		return err
 	}
 
-	if ws == nil {
-		githubactions.Infof("Workspace %q not found, skipping import\n", name)
-		return nil
-	}
-
-	githubactions.Infof("Importing workspace: %s\n", ws.Name)
-
-	err = tf.Import(ctx, address, ws.ID, opts...)
-	if err != nil {
-		return err
-	}
-
-	githubactions.Infof("Successful workspace import: %s\n", ws.Name)
+	githubactions.Infof("Successful workspace import: %s\n", workspace.Name)
 
 	return nil
 }
@@ -94,22 +89,13 @@ func fetchVariableByKey(ctx context.Context, client *tfe.Client, key string, wor
 	return nil, nil
 }
 
-// GetWorkspace returns the requested workspace, nil if the workspace does not exist, an error for any other issues fetching the workspace
-func GetWorkspace(ctx context.Context, client *tfe.Client, organization string, workspace string) (*tfe.Workspace, error) {
-	ws, err := client.Workspaces.Read(ctx, organization, workspace)
-	if err != nil {
-		if err.Error() == "resource not found" {
-			return nil, nil
-		}
-
-		return nil, err
+func ImportVariable(ctx context.Context, tf TerraformCLI, client *tfe.Client, key string, workspace *Workspace, organization string, opts ...tfexec.ImportOption) error {
+	if workspace.ID == nil {
+		githubactions.Infof("Workspace %q not found, skipping import\n", workspace.Name)
+		return nil
 	}
 
-	return ws, nil
-}
-
-func ImportVariable(ctx context.Context, tf TerraformCLI, client *tfe.Client, key string, workspace string, organization string, opts ...tfexec.ImportOption) error {
-	address := fmt.Sprintf("tfe_variable.%s-%s", workspace, key)
+	address := fmt.Sprintf("tfe_variable.%s-%s", workspace.Name, key)
 
 	imp, err := shouldImport(ctx, tf, address)
 	if err != nil {
@@ -123,27 +109,17 @@ func ImportVariable(ctx context.Context, tf TerraformCLI, client *tfe.Client, ke
 
 	githubactions.Infof("Importing variable: %q\n", address)
 
-	ws, err := GetWorkspace(ctx, client, organization, workspace)
-	if err != nil {
-		return err
-	}
-
-	if ws == nil {
-		githubactions.Infof("Workspace %q not found, skipping import\n", workspace)
-		return nil
-	}
-
-	v, err := fetchVariableByKey(ctx, client, key, ws.ID, 1)
+	v, err := fetchVariableByKey(ctx, client, key, *workspace.ID, 1)
 	if err != nil {
 		return err
 	}
 
 	if v == nil {
-		githubactions.Infof("Variable %q for workspace %q not found, skipping import\n", key, workspace)
+		githubactions.Infof("Variable %q for workspace %q not found, skipping import\n", key, workspace.Name)
 		return nil
 	}
 
-	importID := fmt.Sprintf("%s/%s/%s", organization, workspace, v.ID)
+	importID := fmt.Sprintf("%s/%s/%s", organization, workspace.Name, v.ID)
 
 	err = tf.Import(ctx, address, importID, opts...)
 	if err != nil {
@@ -176,7 +152,12 @@ func GetTeam(ctx context.Context, client *tfe.Client, teamName string, organizat
 }
 
 // ImportTeamAccess imports a team access resource by looking up an existing relation
-func ImportTeamAccess(ctx context.Context, tf TerraformCLI, client *tfe.Client, organization string, workspace string, teamName string, opts ...tfexec.ImportOption) error {
+func ImportTeamAccess(ctx context.Context, tf TerraformCLI, client *tfe.Client, organization string, workspace *Workspace, teamName string, opts ...tfexec.ImportOption) error {
+	if workspace.ID == nil {
+		githubactions.Infof("Workspace %q not found, skipping import\n", workspace.Name)
+		return nil
+	}
+
 	team, err := GetTeam(ctx, client, teamName, organization)
 	if err != nil {
 		return err
@@ -186,7 +167,7 @@ func ImportTeamAccess(ctx context.Context, tf TerraformCLI, client *tfe.Client, 
 		return fmt.Errorf("team %q not found", teamName)
 	}
 
-	address := fmt.Sprintf("tfe_team_access.teams[\"%s-%s\"]", workspace, team.ID)
+	address := fmt.Sprintf("tfe_team_access.teams[\"%s-%s\"]", workspace.Name, team.ID)
 
 	imp, err := shouldImport(ctx, tf, address)
 	if err != nil {
@@ -198,20 +179,10 @@ func ImportTeamAccess(ctx context.Context, tf TerraformCLI, client *tfe.Client, 
 		return nil
 	}
 
-	ws, err := GetWorkspace(ctx, client, organization, workspace)
-	if err != nil {
-		return err
-	}
-
-	if ws == nil {
-		githubactions.Infof("Workspace %q not found, skipping import\n", workspace)
-		return nil
-	}
-
 	githubactions.Infof("Importing team access: %q\n", address)
 
 	teamAccess, err := client.TeamAccess.List(ctx, tfe.TeamAccessListOptions{
-		WorkspaceID: &ws.ID,
+		WorkspaceID: workspace.ID,
 	})
 	if err != nil {
 		return err
@@ -226,11 +197,11 @@ func ImportTeamAccess(ctx context.Context, tf TerraformCLI, client *tfe.Client, 
 	}
 
 	if teamAccessID == "" {
-		githubactions.Infof("Team access %q for workspace %q not found, skipping import\n", teamName, workspace)
+		githubactions.Infof("Team access %q for workspace %q not found, skipping import\n", teamName, workspace.Name)
 		return nil
 	}
 
-	importID := fmt.Sprintf("%s/%s/%s", organization, workspace, teamAccessID)
+	importID := fmt.Sprintf("%s/%s/%s", organization, workspace.Name, teamAccessID)
 
 	if err = tf.Import(ctx, address, importID, opts...); err != nil {
 		return err

--- a/internal/action/import_test.go
+++ b/internal/action/import_test.go
@@ -36,6 +36,10 @@ func (tf *TestTFExec) Import(ctx context.Context, address string, ID string, opt
 	return nil
 }
 
+func strPtr(s string) *string {
+	return &s
+}
+
 func TestImportWorkspace(t *testing.T) {
 	ctx := context.Background()
 
@@ -45,8 +49,6 @@ func TestImportWorkspace(t *testing.T) {
 	t.Cleanup(func() {
 		server.Close()
 	})
-
-	mux.HandleFunc("/api/v2/organizations/org/workspaces/ws", testServerResHandler(t, 200, wsAPIResponse))
 
 	client := newTestTFClient(t, server.URL)
 
@@ -63,7 +65,7 @@ func TestImportWorkspace(t *testing.T) {
 			},
 		}
 
-		if err := ImportWorkspace(ctx, &tf, client, "ws", "org"); err != nil {
+		if err := ImportWorkspace(ctx, &tf, client, &Workspace{Name: "ws", ID: strPtr("ws-abc123")}, "org"); err != nil {
 			t.Fatal(err)
 		}
 
@@ -75,7 +77,7 @@ func TestImportWorkspace(t *testing.T) {
 			State: &tfjson.State{},
 		}
 
-		if err := ImportWorkspace(ctx, &tf, client, "ws", "org"); err != nil {
+		if err := ImportWorkspace(ctx, &tf, client, &Workspace{Name: "ws", ID: strPtr("ws-abc123")}, "org"); err != nil {
 			t.Fatal(err)
 		}
 
@@ -85,6 +87,18 @@ func TestImportWorkspace(t *testing.T) {
 			ID:      "ws-abc123",
 			Opts:    ([]tfexec.ImportOption)(nil),
 		})
+	})
+
+	t.Run("skip importing the workspace if the workspace was not set with an ID", func(t *testing.T) {
+		tf := TestTFExec{
+			State: &tfjson.State{},
+		}
+
+		if err := ImportWorkspace(ctx, &tf, client, &Workspace{Name: "ws", ID: nil}, "org"); err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Equal(t, len(tf.ImportArgs), 0)
 	})
 }
 
@@ -100,7 +114,6 @@ func TestImportVariable(t *testing.T) {
 			server.Close()
 		})
 
-		mux.HandleFunc("/api/v2/organizations/org/workspaces/ws", testServerResHandler(t, 200, wsAPIResponse))
 		mux.HandleFunc("/api/v2/workspaces/ws-abc123/vars", testServerResHandler(t, 200, varsAPIResponse))
 
 		client := newTestTFClient(t, server.URL)
@@ -117,7 +130,7 @@ func TestImportVariable(t *testing.T) {
 			},
 		}
 
-		if err := ImportVariable(ctx, &tf, client, "foo", "ws", "org"); err != nil {
+		if err := ImportVariable(ctx, &tf, client, "foo", &Workspace{Name: "ws", ID: strPtr("ws-abc123")}, "org"); err != nil {
 			t.Fatal(err)
 		}
 
@@ -129,7 +142,7 @@ func TestImportVariable(t *testing.T) {
 		})
 	})
 
-	t.Run("skip importing a variable if the workspace does not exist in Terraform Cloud", func(t *testing.T) {
+	t.Run("skip importing a variable if the workspace is not set with an ID", func(t *testing.T) {
 
 		mux := http.NewServeMux()
 		server := httptest.NewServer(mux)
@@ -146,7 +159,7 @@ func TestImportVariable(t *testing.T) {
 			State: &tfjson.State{},
 		}
 
-		if err := ImportVariable(ctx, &tf, client, "foo", "ws", "org"); err != nil {
+		if err := ImportVariable(ctx, &tf, client, "foo", &Workspace{Name: "ws", ID: nil}, "org"); err != nil {
 			t.Fatal(err)
 		}
 
@@ -162,7 +175,6 @@ func TestImportVariable(t *testing.T) {
 			server.Close()
 		})
 
-		mux.HandleFunc("/api/v2/organizations/org/workspaces/ws", testServerResHandler(t, 200, wsAPIResponse))
 		mux.HandleFunc("/api/v2/workspaces/ws-abc123/vars", testServerResHandler(t, 200, `{"data": []}`))
 
 		client := newTestTFClient(t, server.URL)
@@ -179,7 +191,7 @@ func TestImportVariable(t *testing.T) {
 			},
 		}
 
-		if err := ImportVariable(ctx, &tf, client, "foo", "ws", "org"); err != nil {
+		if err := ImportVariable(ctx, &tf, client, "foo", &Workspace{Name: "ws", ID: strPtr("ws-abc123")}, "org"); err != nil {
 			t.Fatal(err)
 		}
 
@@ -199,7 +211,6 @@ func TestImportTeamAccess(t *testing.T) {
 		})
 
 		mux.HandleFunc("/api/v2/organizations/org/teams", testServerResHandler(t, 200, teamAPIResponse))
-		mux.HandleFunc("/api/v2/organizations/org/workspaces/ws", testServerResHandler(t, 200, wsAPIResponse))
 		mux.HandleFunc("/api/v2/team-workspaces", testServerResHandler(t, 200, teamAccessAPIResponse))
 
 		client := newTestTFClient(t, server.URL)
@@ -216,7 +227,7 @@ func TestImportTeamAccess(t *testing.T) {
 			},
 		}
 
-		if err := ImportTeamAccess(ctx, &tf, client, "org", "ws", "Readers"); err != nil {
+		if err := ImportTeamAccess(ctx, &tf, client, "org", &Workspace{Name: "ws", ID: strPtr("ws-abc123")}, "Readers"); err != nil {
 			t.Fatal(err)
 		}
 
@@ -228,7 +239,7 @@ func TestImportTeamAccess(t *testing.T) {
 		})
 	})
 
-	t.Run("skip import if the workspace is not found in Terraform Cloud", func(t *testing.T) {
+	t.Run("skip import if the workspace is not set with an ID", func(t *testing.T) {
 		mux := http.NewServeMux()
 		server := httptest.NewServer(mux)
 
@@ -237,7 +248,6 @@ func TestImportTeamAccess(t *testing.T) {
 		})
 
 		mux.HandleFunc("/api/v2/organizations/org/teams", testServerResHandler(t, 200, teamAPIResponse))
-		mux.HandleFunc("/api/v2/organizations/org/workspaces/ws", testServerResHandler(t, 404, `{}`))
 
 		client := newTestTFClient(t, server.URL)
 
@@ -245,7 +255,7 @@ func TestImportTeamAccess(t *testing.T) {
 			State: &tfjson.State{},
 		}
 
-		if err := ImportTeamAccess(ctx, &tf, client, "org", "ws", "Readers"); err != nil {
+		if err := ImportTeamAccess(ctx, &tf, client, "org", &Workspace{Name: "ws", ID: nil}, "Readers"); err != nil {
 			t.Fatal(err)
 		}
 
@@ -261,7 +271,6 @@ func TestImportTeamAccess(t *testing.T) {
 		})
 
 		mux.HandleFunc("/api/v2/organizations/org/teams", testServerResHandler(t, 200, teamAPIResponse))
-		mux.HandleFunc("/api/v2/organizations/org/workspaces/ws", testServerResHandler(t, 200, wsAPIResponse))
 
 		client := newTestTFClient(t, server.URL)
 
@@ -278,7 +287,7 @@ func TestImportTeamAccess(t *testing.T) {
 			},
 		}
 
-		if err := ImportTeamAccess(ctx, &tf, client, "org", "ws", "Readers"); err != nil {
+		if err := ImportTeamAccess(ctx, &tf, client, "org", &Workspace{Name: "ws", ID: strPtr("ws-abc123")}, "Readers"); err != nil {
 			t.Fatal(err)
 		}
 
@@ -294,7 +303,6 @@ func TestImportTeamAccess(t *testing.T) {
 		})
 
 		mux.HandleFunc("/api/v2/organizations/org/teams", testServerResHandler(t, 200, teamAPIResponse))
-		mux.HandleFunc("/api/v2/organizations/org/workspaces/ws", testServerResHandler(t, 200, wsAPIResponse))
 		mux.HandleFunc("/api/v2/team-workspaces", testServerResHandler(t, 200, `{"data": []}`))
 
 		client := newTestTFClient(t, server.URL)
@@ -311,110 +319,13 @@ func TestImportTeamAccess(t *testing.T) {
 			},
 		}
 
-		if err := ImportTeamAccess(ctx, &tf, client, "org", "ws", "Readers"); err != nil {
+		if err := ImportTeamAccess(ctx, &tf, client, "org", &Workspace{Name: "ws", ID: strPtr("ws-abc123")}, "Readers"); err != nil {
 			t.Fatal(err)
 		}
 
 		assert.Equal(t, len(tf.ImportArgs), 0)
 	})
 }
-
-var wsAPIResponse = `{
-  "data": {
-    "id": "ws-abc123",
-    "type": "workspaces",
-    "attributes": {
-      "allow-destroy-plan": false,
-      "auto-apply": false,
-      "auto-destroy-at": null,
-      "created-at": "2021-08-26T04:43:54.557Z",
-      "environment": "default",
-      "locked": false,
-      "name": "ws",
-      "queue-all-runs": true,
-      "speculative-enabled": true,
-      "structured-run-output-enabled": true,
-      "terraform-version": "1.0.5",
-      "working-directory": "",
-      "global-remote-state": false,
-      "updated-at": "2021-08-26T04:43:54.557Z",
-      "resource-count": 0,
-      "apply-duration-average": null,
-      "plan-duration-average": null,
-      "policy-check-failures": null,
-      "run-failures": null,
-      "workspace-kpis-runs-count": null,
-      "latest-change-at": "2021-08-26T04:43:54.557Z",
-      "operations": true,
-      "execution-mode": "remote",
-      "vcs-repo": null,
-      "vcs-repo-identifier": null,
-      "permissions": {
-        "can-update": true,
-        "can-destroy": true,
-        "can-queue-destroy": true,
-        "can-queue-run": true,
-        "can-queue-apply": true,
-        "can-read-state-versions": true,
-        "can-create-state-versions": true,
-        "can-read-variable": true,
-        "can-update-variable": true,
-        "can-lock": true,
-        "can-unlock": true,
-        "can-force-unlock": true,
-        "can-read-settings": true,
-        "can-manage-tags": true
-      },
-      "actions": {
-        "is-destroyable": false
-      },
-      "description": "",
-      "file-triggers-enabled": true,
-      "trigger-prefixes": [],
-      "source": "tfe-api",
-      "source-name": null,
-      "source-url": null,
-      "tag-names": []
-    },
-    "relationships": {
-      "organization": {
-        "data": {
-          "id": "org",
-          "type": "organizations"
-        }
-      },
-      "current-run": {
-        "data": null
-      },
-      "latest-run": {
-        "data": null
-      },
-      "outputs": {
-        "data": []
-      },
-      "remote-state-consumers": {
-        "links": {
-          "related": "/api/v2/workspaces/ws-abc123/relationships/remote-state-consumers"
-        }
-      },
-      "current-state-version": {
-        "data": null
-      },
-      "current-configuration-version": {
-        "data": null
-      },
-      "agent-pool": {
-        "data": null
-      },
-      "readme": {
-        "data": null
-      }
-    },
-    "links": {
-      "self": "/api/v2/organizations/org/workspaces/ws"
-    }
-  }
-}`
 
 var varsAPIResponse = `{
   "data": [

--- a/internal/action/main.go
+++ b/internal/action/main.go
@@ -80,6 +80,10 @@ func Run() {
 		githubactions.Fatalf("Failed to parse workspaces: %s", err)
 	}
 
+	if err := SetWorkspaceIDs(ctx, client, workspaces, org); err != nil {
+		githubactions.Fatalf("Failed to set workspace IDs: %s", err)
+	}
+
 	genVars := VariablesInput{}
 
 	err = yaml.Unmarshal([]byte(githubactions.GetInput("variables")), &genVars)
@@ -197,21 +201,21 @@ func Run() {
 		githubactions.Infof("Importing resources...\n")
 
 		for _, ws := range workspaces {
-			err = ImportWorkspace(ctx, tf, client, ws.Name, org)
+			err = ImportWorkspace(ctx, tf, client, ws, org)
 			if err != nil {
 				githubactions.Fatalf("Failed to import workspace: %s", err)
 			}
 		}
 
 		for _, v := range variables {
-			err = ImportVariable(ctx, tf, client, v.Key, v.Workspace.Name, org)
+			err = ImportVariable(ctx, tf, client, v.Key, v.Workspace, org)
 			if err != nil {
 				githubactions.Fatalf("Failed to import variable: %s", err)
 			}
 		}
 
 		for _, access := range teamAccess {
-			if err = ImportTeamAccess(ctx, tf, client, org, access.Workspace.Name, access.TeamName); err != nil {
+			if err = ImportTeamAccess(ctx, tf, client, org, access.Workspace, access.TeamName); err != nil {
 				githubactions.Fatalf("Failed to import team access: %s", err)
 			}
 		}

--- a/internal/action/workspace.go
+++ b/internal/action/workspace.go
@@ -16,6 +16,7 @@ import (
 type Workspace struct {
 	Name      string
 	Workspace string
+	ID        *string
 }
 
 // getVCSClientByName looks for a VCS client of the passed type against the VCS clients in the Terraform Cloud organization
@@ -326,4 +327,20 @@ func ParseWorkspaces(workspaceNames []string, name string) ([]*Workspace, error)
 	}
 
 	return workspaces, nil
+}
+
+// SetWorkspaceIDs takes a list of workspace objects and sets the ID if the resources is found in the Terraform Cloud organization
+func SetWorkspaceIDs(ctx context.Context, client *tfe.Client, workspaces []*Workspace, organization string) error {
+	for _, workspace := range workspaces {
+		ws, err := client.Workspaces.Read(ctx, organization, workspace.Name)
+		if err != nil {
+			if err.Error() != "resource not found" {
+				return err
+			}
+		} else {
+			workspace.ID = &ws.ID
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
There were a bunch of instances where we needed to convert a workspace name into a workspace ID. The change looks up the workspaces once and sets the ID on the workspace object. From there, actions that need the workspace ID can check if it exists on their workspace object.

This allows us to remove the GetWorkspace function in favor of checking the passed workspace objects