### PR TITLE
Remove inconsequential NewModule field

### DIFF
--- a/internal/action/workspace.go
+++ b/internal/action/workspace.go
@@ -214,7 +214,6 @@ type NewWorkspaceConfigOptions struct {
 
 func NewModule() *tfconfig.Module {
 	return &tfconfig.Module{
-		Terraform: tfconfig.Terraform{},
 		Data:      map[string]map[string]interface{}{},
 		Resources: map[string]map[string]interface{}{},
 	}


### PR DESCRIPTION
As [noted](https://github.com/TakeScoop/terraform-cloud-workspace-action/pull/72#discussion_r702216319), this field is inconsequential to the returned module, and the NewModule function should return only fields that need to be set by default.
