### PR TITLE
Add integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,4 +33,5 @@ jobs:
     - name: Test
       env:
         tf_token: ${{ secrets.OS_ORG_TF_TOKEN }}
+        tf_organization: ryanwholey
       run: go test -v ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,6 @@ jobs:
 
     - name: Test
       env:
-        tf_token: ${{ secrets.OS_TF_TOKEN }}
-        tf_organization: ryanwholey
+        TF_TOKEN: ${{ secrets.OSS_TF_TOKEN }}
+        TF_ORGANIZATION: ryanwholey
       run: go test -v ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,4 +33,4 @@ jobs:
     - name: Test
       env:
         tf_token: ${{ secrets.OS_ORG_TF_TOKEN }}
-      run: go test -v -run ^(TestCreateWorkspace|TestImportExistingResources|TestDriftCorrection)$ github.com/takescoop/terraform-cloud-workspace-action/internal/
+      run: go test -v ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,4 +33,4 @@ jobs:
     - name: Test
       env:
         tf_token: ${{ secrets.OS_ORG_TF_TOKEN }}
-      run: go test -v -run ^TestDriftCorrection$ github.com/takescoop/terraform-cloud-workspace-action/internal/action
+      run: go test -v ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,4 +33,4 @@ jobs:
     - name: Test
       env:
         tf_token: ${{ secrets.OS_ORG_TF_TOKEN }}
-      run: go test -v ^TestMultipleWorkspaces$ github.com/takescoop/terraform-cloud-workspace-action/internal/action
+      run: go test -v -run ^TestMultipleWorkspaces$ github.com/takescoop/terraform-cloud-workspace-action/internal/action

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,4 +33,4 @@ jobs:
     - name: Test
       env:
         tf_token: ${{ secrets.OS_ORG_TF_TOKEN }}
-      run: go test -v -run ^TestDriftCorrection$ github.com/takescoop/terraform-cloud-workspace-action/internal/action
+      run: go test -v -run ^(TestCreateWorkspace|TestImportExistingResources|TestDriftCorrection)$ github.com/takescoop/terraform-cloud-workspace-action/internal/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,4 +33,4 @@ jobs:
     - name: Test
       env:
         tf_token: ${{ secrets.OS_ORG_TF_TOKEN }}
-      run: go test -v -run ^TestMultipleWorkspaces$ github.com/takescoop/terraform-cloud-workspace-action/internal/action
+      run: go test -v -run ^TestCreateWorkspace$ github.com/takescoop/terraform-cloud-workspace-action/internal/action

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,4 +31,6 @@ jobs:
         go-version: 1.16
 
     - name: Test
+      env:
+        tf_token: ${{ secrets.OS_ORG_TF_TOKEN }}
       run: go test -v ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,6 @@ jobs:
 
     - name: Test
       env:
-        TF_TOKEN: ${{ secrets.OSS_TF_TOKEN }}
-        TF_ORGANIZATION: ryanwholey
+        TF_TOKEN: ${{ secrets.TF_TOKEN_OSS }}
+        TF_ORGANIZATION: takescoop-oss
       run: go test -v ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,4 +33,4 @@ jobs:
     - name: Test
       env:
         tf_token: ${{ secrets.OS_ORG_TF_TOKEN }}
-      run: go test -v ./...
+      run: go test -v ^TestMultipleWorkspaces$ github.com/takescoop/terraform-cloud-workspace-action/internal/action

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,4 +33,4 @@ jobs:
     - name: Test
       env:
         tf_token: ${{ secrets.OS_ORG_TF_TOKEN }}
-      run: go test -v -run ^TestImportExistingResources$ github.com/takescoop/terraform-cloud-workspace-action/internal/action
+      run: go test -v -run ^TestDriftCorrection$ github.com/takescoop/terraform-cloud-workspace-action/internal/action

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,4 +33,4 @@ jobs:
     - name: Test
       env:
         tf_token: ${{ secrets.OS_ORG_TF_TOKEN }}
-      run: go test -v ./...
+      run: go test -v -run ^TestCreateWorkspace$ github.com/takescoop/terraform-cloud-workspace-action/internal/action

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,4 +33,4 @@ jobs:
     - name: Test
       env:
         tf_token: ${{ secrets.OS_ORG_TF_TOKEN }}
-      run: go test -v -run ^TestCreateWorkspace$ github.com/takescoop/terraform-cloud-workspace-action/internal/action
+      run: go test -v -run ^TestImportExistingResources$ github.com/takescoop/terraform-cloud-workspace-action/internal/action

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,6 @@ jobs:
 
     - name: Test
       env:
-        tf_token: ${{ secrets.OS_ORG_TF_TOKEN }}
+        tf_token: ${{ secrets.OS_TF_TOKEN }}
         tf_organization: ryanwholey
       run: go test -v ./...

--- a/README.md
+++ b/README.md
@@ -187,8 +187,8 @@ This project uses [`golangci-lint`](https://github.com/golangci/golangci-lint)
 
 To lint the project
 
-`golangci-lint run`
+`golangci-lint run ./...`
 
 To auto fix issues where supported
 
-`golangci-lint run  --fix`
+`golangci-lint run  --fix ./...`

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ with:
 
 To test the project
 
-`go test`
+`go test -v -short ./...`
 
 ### Lint
 

--- a/internal/action/import.go
+++ b/internal/action/import.go
@@ -138,7 +138,7 @@ func ImportVariable(ctx context.Context, tf TerraformCLI, client *tfe.Client, ke
 func GetTeam(ctx context.Context, client *tfe.Client, teamName string, organization string) (*tfe.Team, error) {
 	teams, err := client.Teams.List(ctx, organization, tfe.TeamListOptions{
 		ListOptions: tfe.ListOptions{
-			PageSize: 100,
+			PageSize: maxPageSize,
 		},
 	})
 	if err != nil {

--- a/internal/action/main.go
+++ b/internal/action/main.go
@@ -164,7 +164,7 @@ func Run(config *Inputs) error {
 	providers := []Provider{
 		{
 			Name:    "tfe",
-			Version: githubactions.GetInput("tfe_provider_version"),
+			Version: config.TFEProviderVersion,
 			Source:  "hashicorp/tfe",
 			Config: tfeprovider.Config{
 				Hostname: config.Host,

--- a/internal/action/main.go
+++ b/internal/action/main.go
@@ -7,49 +7,74 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
-	"strings"
 
 	"github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-exec/tfexec"
 	"github.com/sethvargo/go-githubactions"
-	"github.com/takescoop/terraform-cloud-workspace-action/internal/action/inputs"
 	"github.com/takescoop/terraform-cloud-workspace-action/internal/tfconfig"
 	"github.com/takescoop/terraform-cloud-workspace-action/internal/tfeprovider"
 	yaml "gopkg.in/yaml.v2"
 )
 
-func Run() {
+type RunConfig struct {
+	Token                  string
+	Host                   string
+	Name                   string
+	Organization           string
+	Apply                  bool
+	RunnerTerraformVersion string
+	RemoteStates           string
+	Workspaces             string
+	Variables              string
+	WorkspaceVariables     string
+	TeamAccess             string
+	BackendConfig          string
+	AgentPoolID            string
+	AutoApply              *bool
+	ExecutionMode          string
+	FileTriggersEnabled    *bool
+	GlobalRemoteState      *bool
+	QueueAllRuns           *bool
+	RemoteStateConsumerIDs string
+	SpeculativeEnabled     *bool
+	TerraformVersion       string
+	SSHKeyID               string
+	VCSIngressSubmodules   bool
+	VCSRepo                string
+	VCSTokenID             string
+	VCSType                string
+	WorkingDirectory       string
+	TFEProviderVersion     string
+	Import                 bool
+	AllowWorkspaceDeletion bool
+}
+
+func Run(config *RunConfig) {
 	ctx := context.Background()
 
-	token := githubactions.GetInput("terraform_token")
-	host := githubactions.GetInput("terraform_host")
-	name := strings.TrimSpace(githubactions.GetInput("name"))
-	org := githubactions.GetInput("terraform_organization")
-	apply := inputs.GetBool("apply")
-
 	client, err := tfe.NewClient(&tfe.Config{
-		Address: fmt.Sprintf("https://%s", host),
-		Token:   token,
+		Address: fmt.Sprintf("https://%s", config.Host),
+		Token:   config.Token,
 	})
 	if err != nil {
 		githubactions.Fatalf("Failed to create Terraform client: %s", err)
 	}
 
-	workDir, err := ioutil.TempDir("", name)
+	workDir, err := ioutil.TempDir("", config.Name)
 	if err != nil {
 		githubactions.Fatalf("Failed to create working directory: %s", err)
 	}
 
 	defer os.RemoveAll(workDir)
 
-	tf, err := NewTerraformExec(ctx, workDir, githubactions.GetInput("runner_terraform_version"))
+	tf, err := NewTerraformExec(ctx, workDir, config.RunnerTerraformVersion)
 	if err != nil {
 		githubactions.Fatalf("Failed to create tfexec instance: %s", err)
 	}
 
 	b := []byte(fmt.Sprintf(`credentials "%s" {
 	token = "%s" 
-}`, host, token))
+}`, config.Host, config.Token))
 
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -63,37 +88,37 @@ func Run() {
 
 	var remoteStates map[string]tfconfig.RemoteState
 
-	err = yaml.Unmarshal([]byte(githubactions.GetInput("remote_states")), &remoteStates)
+	err = yaml.Unmarshal([]byte(config.RemoteStates), &remoteStates)
 	if err != nil {
 		githubactions.Fatalf("Failed to parse remote state blocks: %s", err)
 	}
 
 	var wsInputs []string
 
-	err = yaml.Unmarshal([]byte(githubactions.GetInput("workspaces")), &wsInputs)
+	err = yaml.Unmarshal([]byte(config.Workspaces), &wsInputs)
 	if err != nil {
 		githubactions.Fatalf("Failed to decode workspaces: %s", err)
 	}
 
-	workspaces, err := ParseWorkspaces(wsInputs, name)
+	workspaces, err := ParseWorkspaces(wsInputs, config.Name)
 	if err != nil {
 		githubactions.Fatalf("Failed to parse workspaces: %s", err)
 	}
 
-	if err := SetWorkspaceIDs(ctx, client, workspaces, org); err != nil {
+	if err := SetWorkspaceIDs(ctx, client, workspaces, config.Organization); err != nil {
 		githubactions.Fatalf("Failed to set workspace IDs: %s", err)
 	}
 
 	genVars := VariablesInput{}
 
-	err = yaml.Unmarshal([]byte(githubactions.GetInput("variables")), &genVars)
+	err = yaml.Unmarshal([]byte(config.Variables), &genVars)
 	if err != nil {
 		githubactions.Fatalf("Failed to parse variables %s", err)
 	}
 
 	wsVars := WorkspaceVariablesInput{}
 
-	err = yaml.Unmarshal([]byte(githubactions.GetInput("workspace_variables")), &wsVars)
+	err = yaml.Unmarshal([]byte(config.WorkspaceVariables), &wsVars)
 	if err != nil {
 		githubactions.Fatalf("Failed to parse workspace variables %s", err)
 	}
@@ -125,13 +150,13 @@ func Run() {
 
 	var teamInputs TeamAccessInput
 
-	if err = yaml.Unmarshal([]byte(githubactions.GetInput("team_access")), &teamInputs); err != nil {
+	if err = yaml.Unmarshal([]byte(config.TeamAccess), &teamInputs); err != nil {
 		githubactions.Fatalf("Failed to parse teams: %s", err)
 	}
 
 	teamAccess := NewTeamAccess(teamInputs, workspaces)
 
-	backend, err := tfconfig.ParseBackend(githubactions.GetInput("backend_config"))
+	backend, err := tfconfig.ParseBackend(config.BackendConfig)
 	if err != nil {
 		githubactions.Fatalf("Failed to parse backend configuration: %s", err)
 	}
@@ -139,22 +164,22 @@ func Run() {
 	module, err := NewWorkspaceConfig(ctx, client, workspaces, &NewWorkspaceConfigOptions{
 		Backend: backend,
 		WorkspaceResourceOptions: &WorkspaceResourceOptions{
-			AgentPoolID:            githubactions.GetInput("agent_pool_id"),
-			AutoApply:              inputs.GetBoolPtr("auto_apply"),
-			ExecutionMode:          githubactions.GetInput("execution_mode"),
-			FileTriggersEnabled:    inputs.GetBoolPtr("file_triggers_enabled"),
-			GlobalRemoteState:      inputs.GetBoolPtr("global_remote_state"),
-			Organization:           org,
-			QueueAllRuns:           inputs.GetBoolPtr("queue_all_runs"),
-			RemoteStateConsumerIDs: githubactions.GetInput("remote_state_consumer_ids"),
-			SpeculativeEnabled:     inputs.GetBoolPtr("speculative_enabled"),
-			TerraformVersion:       githubactions.GetInput("terraform_version"),
-			SSHKeyID:               githubactions.GetInput("ssh_key_id"),
-			VCSIngressSubmodules:   inputs.GetBool("vcs_ingress_submodules"),
-			VCSRepo:                githubactions.GetInput("vcs_repo"),
-			VCSTokenID:             githubactions.GetInput("vcs_token_id"),
-			VCSType:                githubactions.GetInput("vcs_type"),
-			WorkingDirectory:       githubactions.GetInput("working_directory"),
+			AgentPoolID:            config.AgentPoolID,
+			AutoApply:              config.AutoApply,
+			ExecutionMode:          config.ExecutionMode,
+			FileTriggersEnabled:    config.FileTriggersEnabled,
+			GlobalRemoteState:      config.GlobalRemoteState,
+			Organization:           config.Organization,
+			QueueAllRuns:           config.QueueAllRuns,
+			RemoteStateConsumerIDs: config.RemoteStateConsumerIDs,
+			SpeculativeEnabled:     config.SpeculativeEnabled,
+			TerraformVersion:       config.TerraformVersion,
+			SSHKeyID:               config.SSHKeyID,
+			VCSIngressSubmodules:   config.VCSIngressSubmodules,
+			VCSRepo:                config.VCSRepo,
+			VCSTokenID:             config.VCSTokenID,
+			VCSType:                config.VCSType,
+			WorkingDirectory:       config.WorkingDirectory,
 		},
 		RemoteStates: remoteStates,
 		Variables:    variables,
@@ -162,11 +187,11 @@ func Run() {
 		Providers: []Provider{
 			{
 				Name:    "tfe",
-				Version: githubactions.GetInput("tfe_provider_version"),
+				Version: config.TFEProviderVersion,
 				Source:  "hashicorp/tfe",
 				Config: tfeprovider.Config{
-					Hostname: host,
-					Token:    token,
+					Hostname: config.Host,
+					Token:    config.Token,
 				},
 			},
 		},
@@ -185,8 +210,8 @@ func Run() {
 		githubactions.Fatalf("Failed to copy state to a local backend: %s", err)
 	}
 
-	if inputs.GetBool("import") {
-		if err = ImportResources(ctx, client, tf, module, filePath, workspaces, org); err != nil {
+	if config.Import {
+		if err = ImportResources(ctx, client, tf, module, filePath, workspaces, config.Organization); err != nil {
 			githubactions.Fatalf("Failed to import resources: %s", err)
 		}
 	}
@@ -223,14 +248,14 @@ func Run() {
 
 		githubactions.SetOutput("plan_json", string(b))
 
-		if !inputs.GetBool("allow_workspace_deletion") && WillDestroy(plan, "tfe_workspace") {
+		if !config.AllowWorkspaceDeletion && WillDestroy(plan, "tfe_workspace") {
 			githubactions.Fatalf("Error: allow_workspace_deletion must be true to allow workspace deletion. Deleting a workspace will permanently, irrecoverably delete all of its stored Terraform state versions.")
 		}
 	} else {
 		githubactions.Infof("No changes\n")
 	}
 
-	if apply {
+	if config.Apply {
 		githubactions.Infof("Applying...\n")
 
 		if err = CopyStateToBackend(ctx, tf, module, backend, filePath); err != nil {

--- a/internal/action/main_test.go
+++ b/internal/action/main_test.go
@@ -132,7 +132,7 @@ func TestCreateWorkspace(t *testing.T) {
 		t.Fatal("workspace should not exist, and an error should be returned")
 	}
 
-	if errors.Is(err, tfe.ErrResourceNotFound) {
+	if !errors.Is(err, tfe.ErrResourceNotFound) {
 		t.Fatalf("Error is not workspace not found: %s", err)
 	}
 

--- a/internal/action/main_test.go
+++ b/internal/action/main_test.go
@@ -234,85 +234,105 @@ func TestDriftCorrection(t *testing.T) {
 	})
 }
 
-// func TestMultipleWorkspaces(t *testing.T) {
-// 	if testing.Short() {
-// 		t.Skip("skipping integration test")
-// 	}
+func TestMultipleWorkspaces(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
 
-// 	ctx := context.Background()
+	ctx := context.Background()
 
-// 	envs := map[string]string{
-// 		"terraform_token":        os.Getenv("tf_token"),
-// 		"terraform_organization": "ryanwholey",
-// 		"terraform_host":         "app.terraform.io",
-// 		"name":                   fmt.Sprintf("%s-%d", workspacePrefix, time.Now().Unix()),
-// 		"workspaces": `---
-// - staging
-// - production`,
-// 		"workspace_variables": `---
-// staging:
-//   - key: environment
-//     value: staging
-//     category: env
-// production:
-//   - key: environment
-//     value: production
-//     category: env`,
-// 		"import":                   "true",
-// 		"apply":                    "true",
-// 		"tfe_provider_version":     "0.25.3",
-// 		"runner_terraform_version": "1.0.5",
-// 		"terraform_version":        "1.0.5",
-// 	}
+	envs := map[string]string{
+		"terraform_token":        os.Getenv("tf_token"),
+		"terraform_organization": "ryanwholey",
+		"terraform_host":         "app.terraform.io",
+		"name":                   fmt.Sprintf("%s-%d", workspacePrefix, time.Now().Unix()),
+		"workspaces": `---
+- staging
+- production`,
+		"workspace_variables": `---
+staging:
+  - key: environment
+    value: staging
+    category: env
+production:
+  - key: environment
+    value: production
+    category: env`,
+		"import":                   "true",
+		"apply":                    "true",
+		"tfe_provider_version":     "0.25.3",
+		"runner_terraform_version": "1.0.5",
+		"terraform_version":        "1.0.5",
+	}
 
-// 	SetTestEnvs(envs)
+	config := &RunConfig{
+		Token:        os.Getenv("tf_token"),
+		Organization: "ryanwholey",
+		Host:         "app.terraform.io",
+		Name:         fmt.Sprintf("%s-%d", workspacePrefix, time.Now().Unix()),
+		Workspaces: `---
+- staging
+- production`,
+		WorkspaceVariables: `---
+staging:
+  - key: environment
+    value: staging
+    category: env
+production:
+  - key: environment
+    value: production
+    category: env`,
+		Import:                 true,
+		Apply:                  true,
+		TFEProviderVersion:     "0.25.3",
+		RunnerTerraformVersion: "1.0.5",
+		TerraformVersion:       "1.0.5",
+	}
 
-// 	client, err := tfe.NewClient(&tfe.Config{
-// 		Address: fmt.Sprintf("https://%s", envs["terraform_host"]),
-// 		Token:   envs["terraform_token"],
-// 	})
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
+	client, err := tfe.NewClient(&tfe.Config{
+		Address: fmt.Sprintf("https://%s", config.Host),
+		Token:   config.Token,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 
-// 	if err := RemoveTestWorkspaces(ctx, client, envs["terraform_organization"], workspacePrefix); err != nil {
-// 		t.Fatal(err)
-// 	}
+	if err := RemoveTestWorkspaces(ctx, client, config.Organization, workspacePrefix); err != nil {
+		t.Fatal(err)
+	}
 
-// 	ws, err := client.Workspaces.List(ctx, envs["terraform_organization"], tfe.WorkspaceListOptions{
-// 		Search: &workspacePrefix,
-// 	})
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
+	ws, err := client.Workspaces.List(ctx, config.Organization, tfe.WorkspaceListOptions{
+		Search: &workspacePrefix,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 
-// 	assert.Equal(t, len(ws.Items), 0)
+	assert.Equal(t, len(ws.Items), 0)
 
-// 	Run()
+	Run(config)
 
-// 	ws, err = client.Workspaces.List(ctx, envs["terraform_organization"], tfe.WorkspaceListOptions{
-// 		Search: &workspacePrefix,
-// 	})
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
+	ws, err = client.Workspaces.List(ctx, config.Organization, tfe.WorkspaceListOptions{
+		Search: &workspacePrefix,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 
-// 	assert.Equal(t, len(ws.Items), 2)
+	assert.Equal(t, len(ws.Items), 2)
 
-// 	for _, ws := range ws.Items {
-// 		v, err := client.Variables.List(ctx, ws.ID, tfe.VariableListOptions{})
-// 		if err != nil {
-// 			t.Fatal(err)
-// 		}
+	for _, ws := range ws.Items {
+		v, err := client.Variables.List(ctx, ws.ID, tfe.VariableListOptions{})
+		if err != nil {
+			t.Fatal(err)
+		}
 
-// 		assert.Equal(t, len(v.Items), 1)
-// 	}
+		assert.Equal(t, len(v.Items), 1)
+	}
 
-// 	t.Cleanup(func() {
-// 		UnsetTestEnvs(envs)
-
-// 		if err := RemoveTestWorkspaces(ctx, client, envs["terraform_organization"], workspacePrefix); err != nil {
-// 			t.Fatal(err)
-// 		}
-// 	})
-// }
+	t.Cleanup(func() {
+		if err := RemoveTestWorkspaces(ctx, client, envs["terraform_organization"], workspacePrefix); err != nil {
+			t.Fatal(err)
+		}
+	})
+}

--- a/internal/action/main_test.go
+++ b/internal/action/main_test.go
@@ -162,7 +162,7 @@ func TestImportExistingResources(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, v.Category, *tfe.Category(tfe.CategoryEnv))
+	assert.Equal(t, v.Value, "bar")
 
 	Run()
 

--- a/internal/action/main_test.go
+++ b/internal/action/main_test.go
@@ -2,49 +2,108 @@ package action
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/ioutil"
 	"os"
+	"strconv"
 	"testing"
 	"time"
 
 	"github.com/hashicorp/go-tfe"
 	"github.com/stretchr/testify/assert"
+	yaml "gopkg.in/yaml.v2"
 )
 
-var workspacePrefix string = "action-test"
+var testWorkspacePrefix string = "action-test"
 
-func NewTestRunConfig() *RunConfig {
-	return &RunConfig{
+// newTestInputs returns an Inputs object with test defaults
+func newTestInputs(t *testing.T) *Inputs {
+	action, err := getActionConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	imp, err := strconv.ParseBool(action.Inputs["import"].Default)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	token := os.Getenv("tf_token")
+	if token == "" {
+		t.Fatal(`Error: "TF_TOKEN" must be set in the environment`)
+	}
+
+	organization := os.Getenv("tf_organization")
+	if organization == "" {
+		t.Fatal(`Error: "TF_ORGANIZATION" must be set in the environment`)
+	}
+
+	return &Inputs{
 		Token:                  os.Getenv("tf_token"),
 		Organization:           os.Getenv("tf_organization"),
-		Host:                   "app.terraform.io",
-		Name:                   fmt.Sprintf("%s-%d", workspacePrefix, time.Now().Unix()),
-		Import:                 true,
+		Host:                   action.Inputs["terraform_host"].Default,
+		Name:                   fmt.Sprintf("%s-%d", testWorkspacePrefix, time.Now().Unix()),
+		Import:                 imp,
 		Apply:                  true,
-		TFEProviderVersion:     "0.25.3",
-		RunnerTerraformVersion: "1.0.5",
-		TerraformVersion:       "1.0.5",
+		TFEProviderVersion:     action.Inputs["tfe_provider_version"].Default,
+		RunnerTerraformVersion: action.Inputs["runner_terraform_version"].Default,
+		TerraformVersion:       action.Inputs["terraform_version"].Default,
 	}
 }
 
-func RemoveTestWorkspaces(ctx context.Context, client *tfe.Client, organization string, prefix string) error {
-	workspaces, err := client.Workspaces.List(ctx, organization, tfe.WorkspaceListOptions{
-		Search: &prefix,
+// removeTestWorkspacesFunc returns a function that removes all workspaces created by the integration tests
+func removeTestWorkspacesFunc(t *testing.T, ctx context.Context, client *tfe.Client) func() {
+	return func() {
+		removeTestWorkspaces(t, ctx, client)
+	}
+}
+
+// removeTestWorkspaces deletes all test workspaces created by these tests
+func removeTestWorkspaces(t *testing.T, ctx context.Context, client *tfe.Client) {
+	workspaces, err := client.Workspaces.List(ctx, "org", tfe.WorkspaceListOptions{
+		Search: tfe.String(testWorkspacePrefix),
 		ListOptions: tfe.ListOptions{
-			PageSize: 100,
+			PageSize: maxPageSize,
 		},
 	})
 	if err != nil {
-		return err
+		t.Fatal(err)
 	}
 
 	for _, ws := range workspaces.Items {
 		if err := client.Workspaces.DeleteByID(ctx, ws.ID); err != nil {
-			return err
+			t.Fatal(err)
 		}
 	}
+}
 
-	return nil
+type ActionInput struct {
+	Description string `yaml:"description"`
+	Required    bool   `yaml:"required"`
+	Default     string `yaml:"default"`
+}
+
+type ActionConfig struct {
+	Name        string                 `yaml:"name"`
+	Description string                 `yaml:"description"`
+	Inputs      map[string]ActionInput `yaml:"inputs"`
+}
+
+// getActionConfig returns the action configuration file
+func getActionConfig() (*ActionConfig, error) {
+	actionFile, err := ioutil.ReadFile("../../action.yml")
+	if err != nil {
+		return nil, err
+	}
+
+	var action ActionConfig
+
+	if err := yaml.Unmarshal(actionFile, &action); err != nil {
+		return nil, err
+	}
+
+	return &action, nil
 }
 
 func TestCreateWorkspace(t *testing.T) {
@@ -54,7 +113,7 @@ func TestCreateWorkspace(t *testing.T) {
 
 	ctx := context.Background()
 
-	config := NewTestRunConfig()
+	config := newTestInputs(t)
 
 	client, err := tfe.NewClient(&tfe.Config{
 		Address: fmt.Sprintf("https://%s", config.Host),
@@ -64,20 +123,22 @@ func TestCreateWorkspace(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := RemoveTestWorkspaces(ctx, client, config.Organization, workspacePrefix); err != nil {
-		t.Fatal(err)
-	}
+	t.Cleanup(removeTestWorkspacesFunc(t, ctx, client))
+
+	removeTestWorkspaces(t, ctx, client)
 
 	_, err = client.Workspaces.Read(ctx, config.Organization, config.Name)
 	if err == nil {
 		t.Fatal("workspace should not exist, and an error should be returned")
 	}
 
-	if err.Error() != "resource not found" {
+	if errors.Is(err, tfe.ErrResourceNotFound) {
 		t.Fatalf("Error is not workspace not found: %s", err)
 	}
 
-	Run(config)
+	if err = Run(config); err != nil {
+		t.Fatal(err)
+	}
 
 	ws, err := client.Workspaces.Read(ctx, config.Organization, config.Name)
 	if err != nil {
@@ -85,12 +146,6 @@ func TestCreateWorkspace(t *testing.T) {
 	}
 
 	assert.Equal(t, ws.Name, config.Name)
-
-	t.Cleanup(func() {
-		if err := RemoveTestWorkspaces(ctx, client, config.Organization, workspacePrefix); err != nil {
-			t.Fatal(err)
-		}
-	})
 }
 
 func TestImportExistingResources(t *testing.T) {
@@ -100,7 +155,7 @@ func TestImportExistingResources(t *testing.T) {
 
 	ctx := context.Background()
 
-	config := NewTestRunConfig()
+	config := newTestInputs(t)
 
 	config.Variables = `---
 - key: foo
@@ -115,13 +170,13 @@ func TestImportExistingResources(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := RemoveTestWorkspaces(ctx, client, config.Organization, workspacePrefix); err != nil {
-		t.Fatal(err)
-	}
+	t.Cleanup(removeTestWorkspacesFunc(t, ctx, client))
+
+	removeTestWorkspaces(t, ctx, client)
 
 	ws, err := client.Workspaces.Create(ctx, config.Organization, tfe.WorkspaceCreateOptions{
 		Name:             &config.Name,
-		TerraformVersion: strPtr("1.0.4"),
+		TerraformVersion: tfe.String("1.0.4"),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -130,8 +185,8 @@ func TestImportExistingResources(t *testing.T) {
 	assert.Equal(t, ws.TerraformVersion, "1.0.4")
 
 	v, err := client.Variables.Create(ctx, ws.ID, tfe.VariableCreateOptions{
-		Key:      strPtr("foo"),
-		Value:    strPtr("bar"),
+		Key:      tfe.String("foo"),
+		Value:    tfe.String("bar"),
 		Category: tfe.Category(tfe.CategoryTerraform),
 	})
 	if err != nil {
@@ -140,7 +195,9 @@ func TestImportExistingResources(t *testing.T) {
 
 	assert.Equal(t, v.Value, "bar")
 
-	Run(config)
+	if err = Run(config); err != nil {
+		t.Fatal(err)
+	}
 
 	ws, err = client.Workspaces.Read(ctx, config.Organization, config.Name)
 	if err != nil {
@@ -155,12 +212,6 @@ func TestImportExistingResources(t *testing.T) {
 	}
 
 	assert.Equal(t, v.Value, "baz")
-
-	t.Cleanup(func() {
-		if err := RemoveTestWorkspaces(ctx, client, config.Organization, workspacePrefix); err != nil {
-			t.Fatal(err)
-		}
-	})
 }
 
 func TestDriftCorrection(t *testing.T) {
@@ -170,7 +221,7 @@ func TestDriftCorrection(t *testing.T) {
 
 	ctx := context.Background()
 
-	config := NewTestRunConfig()
+	config := newTestInputs(t)
 
 	client, err := tfe.NewClient(&tfe.Config{
 		Address: fmt.Sprintf("https://%s", config.Host),
@@ -180,9 +231,9 @@ func TestDriftCorrection(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := RemoveTestWorkspaces(ctx, client, config.Organization, workspacePrefix); err != nil {
-		t.Fatal(err)
-	}
+	t.Cleanup(removeTestWorkspacesFunc(t, ctx, client))
+
+	removeTestWorkspaces(t, ctx, client)
 
 	ws, err := client.Workspaces.Create(ctx, config.Organization, tfe.WorkspaceCreateOptions{
 		Name:             &config.Name,
@@ -193,30 +244,26 @@ func TestDriftCorrection(t *testing.T) {
 	}
 
 	v, err := client.Variables.Create(ctx, ws.ID, tfe.VariableCreateOptions{
-		Key:      strPtr("foo"),
-		Value:    strPtr("bar"),
+		Key:      tfe.String("foo"),
+		Value:    tfe.String("bar"),
 		Category: tfe.Category(tfe.CategoryTerraform),
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	Run(config)
+	if err = Run(config); err != nil {
+		t.Fatal(err)
+	}
 
 	_, err = client.Variables.Read(ctx, ws.ID, v.ID)
 	if err == nil {
 		t.Fatal("Expected variable not to exist")
 	}
 
-	if err.Error() != "resource not found" {
+	if errors.Is(err, tfe.ErrResourceNotFound) {
 		t.Fatalf("Expected error to be resource not found: %s", err)
 	}
-
-	t.Cleanup(func() {
-		if err := RemoveTestWorkspaces(ctx, client, config.Organization, workspacePrefix); err != nil {
-			t.Fatal(err)
-		}
-	})
 }
 
 func TestMultipleWorkspaces(t *testing.T) {
@@ -226,7 +273,7 @@ func TestMultipleWorkspaces(t *testing.T) {
 
 	ctx := context.Background()
 
-	config := NewTestRunConfig()
+	config := newTestInputs(t)
 
 	config.Workspaces = `---
 - staging
@@ -250,29 +297,31 @@ production:
 		t.Fatal(err)
 	}
 
-	if err := RemoveTestWorkspaces(ctx, client, config.Organization, workspacePrefix); err != nil {
-		t.Fatal(err)
-	}
+	t.Cleanup(removeTestWorkspacesFunc(t, ctx, client))
+
+	removeTestWorkspaces(t, ctx, client)
 
 	ws, err := client.Workspaces.List(ctx, config.Organization, tfe.WorkspaceListOptions{
-		Search: &workspacePrefix,
+		Search: &testWorkspacePrefix,
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, len(ws.Items), 0)
+	assert.Len(t, ws.Items, 0)
 
-	Run(config)
+	if err = Run(config); err != nil {
+		t.Fatal(err)
+	}
 
 	ws, err = client.Workspaces.List(ctx, config.Organization, tfe.WorkspaceListOptions{
-		Search: &workspacePrefix,
+		Search: &testWorkspacePrefix,
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, len(ws.Items), 2)
+	assert.Len(t, ws.Items, 2)
 
 	for _, ws := range ws.Items {
 		v, err := client.Variables.List(ctx, ws.ID, tfe.VariableListOptions{})
@@ -280,12 +329,6 @@ production:
 			t.Fatal(err)
 		}
 
-		assert.Equal(t, len(v.Items), 1)
+		assert.Len(t, v.Items, 1)
 	}
-
-	t.Cleanup(func() {
-		if err := RemoveTestWorkspaces(ctx, client, config.Organization, workspacePrefix); err != nil {
-			t.Fatal(err)
-		}
-	})
 }

--- a/internal/action/main_test.go
+++ b/internal/action/main_test.go
@@ -125,8 +125,8 @@ func TestImportExistingResources(t *testing.T) {
 		"terraform_version":        "1.0.5",
 		"variables": `---
 - key: foo
-	value: baz
-	category: terraform`,
+  value: baz
+  category: terraform`,
 	}
 
 	SetTestEnvs(envs)

--- a/internal/action/main_test.go
+++ b/internal/action/main_test.go
@@ -40,8 +40,8 @@ func newTestInputs(t *testing.T) *Inputs {
 	}
 
 	return &Inputs{
-		Token:                  os.Getenv("tf_token"),
-		Organization:           os.Getenv("tf_organization"),
+		Token:                  token,
+		Organization:           organization,
 		Host:                   action.Inputs["terraform_host"].Default,
 		Name:                   fmt.Sprintf("%s-%d", testWorkspacePrefix, time.Now().Unix()),
 		Import:                 imp,

--- a/internal/action/main_test.go
+++ b/internal/action/main_test.go
@@ -66,5 +66,4 @@ func TestCreateWorkspace(t *testing.T) {
 			t.Fatal(err)
 		}
 	})
-
 }

--- a/internal/action/main_test.go
+++ b/internal/action/main_test.go
@@ -61,13 +61,13 @@ func removeTestWorkspacesFunc(t *testing.T, ctx context.Context, client *tfe.Cli
 
 // removeTestWorkspaces deletes all test workspaces created by these tests
 func removeTestWorkspaces(t *testing.T, ctx context.Context, client *tfe.Client) {
-	workspaces, err := client.Workspaces.List(ctx, "org", tfe.WorkspaceListOptions{
+	workspaces, err := client.Workspaces.List(ctx, os.Getenv("TF_ORGANIZATION"), tfe.WorkspaceListOptions{
 		Search: tfe.String(testWorkspacePrefix),
 		ListOptions: tfe.ListOptions{
 			PageSize: maxPageSize,
 		},
 	})
-	if !errors.Is(err, tfe.ErrResourceNotFound) {
+	if err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/action/main_test.go
+++ b/internal/action/main_test.go
@@ -16,7 +16,7 @@ var workspacePrefix string = "action-test"
 func NewTestRunConfig() *RunConfig {
 	return &RunConfig{
 		Token:                  os.Getenv("tf_token"),
-		Organization:           "ryanwholey",
+		Organization:           os.Getenv("tf_organization"),
 		Host:                   "app.terraform.io",
 		Name:                   fmt.Sprintf("%s-%d", workspacePrefix, time.Now().Unix()),
 		Import:                 true,

--- a/internal/action/main_test.go
+++ b/internal/action/main_test.go
@@ -67,7 +67,7 @@ func removeTestWorkspaces(t *testing.T, ctx context.Context, client *tfe.Client)
 			PageSize: maxPageSize,
 		},
 	})
-	if err != nil {
+	if !errors.Is(err, tfe.ErrResourceNotFound) {
 		t.Fatal(err)
 	}
 

--- a/internal/action/main_test.go
+++ b/internal/action/main_test.go
@@ -168,75 +168,71 @@ func TestImportExistingResources(t *testing.T) {
 	})
 }
 
-// func TestDriftCorrection(t *testing.T) {
-// 	if testing.Short() {
-// 		t.Skip("skipping integration test")
-// 	}
+func TestDriftCorrection(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
 
-// 	ctx := context.Background()
+	ctx := context.Background()
 
-// 	envs := map[string]string{
-// 		"terraform_token":          os.Getenv("tf_token"),
-// 		"terraform_organization":   "ryanwholey",
-// 		"terraform_host":           "app.terraform.io",
-// 		"name":                     fmt.Sprintf("%s-%d", workspacePrefix, time.Now().Unix()),
-// 		"import":                   "true",
-// 		"apply":                    "true",
-// 		"tfe_provider_version":     "0.25.3",
-// 		"runner_terraform_version": "1.0.5",
-// 		"terraform_version":        "1.0.5",
-// 	}
+	config := &RunConfig{
+		Token:                  os.Getenv("tf_token"),
+		Organization:           "ryanwholey",
+		Host:                   "app.terraform.io",
+		Name:                   fmt.Sprintf("%s-%d", workspacePrefix, time.Now().Unix()),
+		Import:                 true,
+		Apply:                  true,
+		TFEProviderVersion:     "0.25.3",
+		RunnerTerraformVersion: "1.0.5",
+		TerraformVersion:       "1.0.5",
+	}
 
-// 	SetTestEnvs(envs)
+	client, err := tfe.NewClient(&tfe.Config{
+		Address: fmt.Sprintf("https://%s", config.Host),
+		Token:   config.Token,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 
-// 	client, err := tfe.NewClient(&tfe.Config{
-// 		Address: fmt.Sprintf("https://%s", envs["terraform_host"]),
-// 		Token:   envs["terraform_token"],
-// 	})
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
+	if err := RemoveTestWorkspaces(ctx, client, config.Organization, workspacePrefix); err != nil {
+		t.Fatal(err)
+	}
 
-// 	if err := RemoveTestWorkspaces(ctx, client, envs["terraform_organization"], workspacePrefix); err != nil {
-// 		t.Fatal(err)
-// 	}
+	ws, err := client.Workspaces.Create(ctx, config.Organization, tfe.WorkspaceCreateOptions{
+		Name:             &config.Name,
+		TerraformVersion: &config.TerraformVersion,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 
-// 	ws, err := client.Workspaces.Create(ctx, envs["terraform_organization"], tfe.WorkspaceCreateOptions{
-// 		Name:             strPtr(envs["name"]),
-// 		TerraformVersion: strPtr("1.0.5"),
-// 	})
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
+	v, err := client.Variables.Create(ctx, ws.ID, tfe.VariableCreateOptions{
+		Key:      strPtr("foo"),
+		Value:    strPtr("bar"),
+		Category: tfe.Category(tfe.CategoryTerraform),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 
-// 	v, err := client.Variables.Create(ctx, ws.ID, tfe.VariableCreateOptions{
-// 		Key:      strPtr("foo"),
-// 		Value:    strPtr("bar"),
-// 		Category: tfe.Category(tfe.CategoryTerraform),
-// 	})
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
+	Run(config)
 
-// 	Run()
+	_, err = client.Variables.Read(ctx, ws.ID, v.ID)
+	if err == nil {
+		t.Fatal("Expected variable not to exist")
+	}
 
-// 	_, err = client.Variables.Read(ctx, ws.ID, v.ID)
-// 	if err == nil {
-// 		t.Fatal("Expected variable not to exist")
-// 	}
+	if err.Error() != "resource not found" {
+		t.Fatalf("Expected error to be resource not found: %s", err)
+	}
 
-// 	if err.Error() != "resource not found" {
-// 		t.Fatalf("Expected error to be resource not found: %s", err)
-// 	}
-
-// 	t.Cleanup(func() {
-// 		UnsetTestEnvs(envs)
-
-// 		if err := RemoveTestWorkspaces(ctx, client, envs["terraform_organization"], workspacePrefix); err != nil {
-// 			t.Fatal(err)
-// 		}
-// 	})
-// }
+	t.Cleanup(func() {
+		if err := RemoveTestWorkspaces(ctx, client, config.Organization, workspacePrefix); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
 
 // func TestMultipleWorkspaces(t *testing.T) {
 // 	if testing.Short() {

--- a/internal/action/main_test.go
+++ b/internal/action/main_test.go
@@ -35,7 +35,7 @@ func TestCreateWorkspace(t *testing.T) {
 	}
 
 	client, err := tfe.NewClient(&tfe.Config{
-		Address: envs["terraform_host"],
+		Address: fmt.Sprintf("https://%s", envs["terraform_host"]),
 		Token:   envs["terraform_token"],
 	})
 	if err != nil {

--- a/internal/action/main_test.go
+++ b/internal/action/main_test.go
@@ -242,9 +242,10 @@ func TestDriftCorrection(t *testing.T) {
 	Run()
 
 	_, err = client.Variables.Read(ctx, ws.ID, v.ID)
-	if err != nil {
+	if err == nil {
 		t.Fatal("Expected variable not to exist")
 	}
+
 	if err.Error() != "resource not found" {
 		t.Fatalf("Expected error to be resource not found: %s", err)
 	}

--- a/internal/action/main_test.go
+++ b/internal/action/main_test.go
@@ -29,12 +29,12 @@ func newTestInputs(t *testing.T) *Inputs {
 		t.Fatal(err)
 	}
 
-	token := os.Getenv("tf_token")
+	token := os.Getenv("TF_TOKEN")
 	if token == "" {
 		t.Fatal(`Error: "TF_TOKEN" must be set in the environment`)
 	}
 
-	organization := os.Getenv("tf_organization")
+	organization := os.Getenv("TF_ORGANIZATION")
 	if organization == "" {
 		t.Fatal(`Error: "TF_ORGANIZATION" must be set in the environment`)
 	}

--- a/internal/action/main_test.go
+++ b/internal/action/main_test.go
@@ -1,0 +1,70 @@
+package action
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/go-tfe"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateWorkspace(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	ctx := context.Background()
+
+	envs := map[string]string{
+		"terraform_token":          os.Getenv("tf_token"),
+		"terrafrm_organization":    "ryanwholey",
+		"terraform_host":           "app.terraform.io",
+		"name":                     "action-test",
+		"import":                   "true",
+		"apply":                    "true",
+		"tfe_provider_version":     "0.25.3",
+		"runner_terraform_version": "1.0.5",
+		"terraform_version":        "1.0.5",
+	}
+
+	for key, value := range envs {
+		os.Setenv(fmt.Sprintf("INPUT_%s", strings.ToUpper(key)), value)
+	}
+
+	client, err := tfe.NewClient(&tfe.Config{
+		Address: envs["terraform_host"],
+		Token:   envs["terraform_token"],
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.Workspaces.Read(ctx, envs["terraform_organization"], envs["name"])
+	if err.Error() != "resource not found" {
+		t.Fatal("test workspace already exists")
+	}
+
+	Run()
+
+	ws, err := client.Workspaces.Read(ctx, envs["terraform_organization"], envs["name"])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, ws.Name, envs["name"])
+
+	t.Cleanup(func() {
+		for key := range envs {
+			os.Unsetenv(fmt.Sprintf("INPUT_%s", strings.ToUpper(key)))
+		}
+
+		err = client.Workspaces.Delete(ctx, envs["terraform_organization"], envs["name"])
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+}

--- a/internal/action/main_test.go
+++ b/internal/action/main_test.go
@@ -20,7 +20,7 @@ func TestCreateWorkspace(t *testing.T) {
 
 	envs := map[string]string{
 		"terraform_token":          os.Getenv("tf_token"),
-		"terrafrm_organization":    "ryanwholey",
+		"terraform_organization":   "ryanwholey",
 		"terraform_host":           "app.terraform.io",
 		"name":                     "action-test",
 		"import":                   "true",
@@ -43,12 +43,11 @@ func TestCreateWorkspace(t *testing.T) {
 	}
 
 	_, err = client.Workspaces.Read(ctx, envs["terraform_organization"], envs["name"])
-	if err != nil {
-		fmt.Println(envs["name"])
-		fmt.Println(err.Error())
+	if err == nil {
+		t.Fatal("workspace should not exist, and an error should be returned")
 	}
 	if err.Error() != "resource not found" {
-		t.Fatal("test workspace already exists")
+		t.Fatalf("Error is not workspace not found: %s", err)
 	}
 
 	Run()

--- a/internal/action/main_test.go
+++ b/internal/action/main_test.go
@@ -6,10 +6,43 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/go-tfe"
 	"github.com/stretchr/testify/assert"
 )
+
+func RemoveTestWorkspaces(ctx context.Context, client *tfe.Client, organization string, prefix string) error {
+	workspaces, err := client.Workspaces.List(ctx, organization, tfe.WorkspaceListOptions{
+		Search: &prefix,
+		ListOptions: tfe.ListOptions{
+			PageSize: 100,
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, ws := range workspaces.Items {
+		if err := client.Workspaces.DeleteByID(ctx, ws.ID); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func SetTestEnvs(envs map[string]string) {
+	for key, value := range envs {
+		os.Setenv(fmt.Sprintf("INPUT_%s", strings.ToUpper(key)), value)
+	}
+}
+
+func UnsetTestEnvs(envs map[string]string) {
+	for key := range envs {
+		os.Unsetenv(fmt.Sprintf("INPUT_%s", strings.ToUpper(key)))
+	}
+}
 
 func TestCreateWorkspace(t *testing.T) {
 	if testing.Short() {
@@ -22,7 +55,7 @@ func TestCreateWorkspace(t *testing.T) {
 		"terraform_token":          os.Getenv("tf_token"),
 		"terraform_organization":   "ryanwholey",
 		"terraform_host":           "app.terraform.io",
-		"name":                     "action-test",
+		"name":                     fmt.Sprintf("action-test-%d", time.Now().Unix()),
 		"import":                   "true",
 		"apply":                    "true",
 		"tfe_provider_version":     "0.25.3",
@@ -30,15 +63,17 @@ func TestCreateWorkspace(t *testing.T) {
 		"terraform_version":        "1.0.5",
 	}
 
-	for key, value := range envs {
-		os.Setenv(fmt.Sprintf("INPUT_%s", strings.ToUpper(key)), value)
-	}
+	SetTestEnvs(envs)
 
 	client, err := tfe.NewClient(&tfe.Config{
 		Address: fmt.Sprintf("https://%s", envs["terraform_host"]),
 		Token:   envs["terraform_token"],
 	})
 	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := RemoveTestWorkspaces(ctx, client, envs["terraform_organization"], "action-test"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -60,13 +95,56 @@ func TestCreateWorkspace(t *testing.T) {
 	assert.Equal(t, ws.Name, envs["name"])
 
 	t.Cleanup(func() {
-		for key := range envs {
-			os.Unsetenv(fmt.Sprintf("INPUT_%s", strings.ToUpper(key)))
-		}
+		UnsetTestEnvs(envs)
 
 		err = client.Workspaces.Delete(ctx, envs["terraform_organization"], envs["name"])
 		if err != nil {
 			t.Fatal(err)
 		}
 	})
+}
+
+func TestImportExistingResources(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	ctx := context.Background()
+
+	envs := map[string]string{
+		"terraform_token":          os.Getenv("tf_token"),
+		"terraform_organization":   "ryanwholey",
+		"terraform_host":           "app.terraform.io",
+		"name":                     fmt.Sprintf("action-test-%d", time.Now().Unix()),
+		"import":                   "true",
+		"apply":                    "true",
+		"tfe_provider_version":     "0.25.3",
+		"runner_terraform_version": "1.0.5",
+		"terraform_version":        "1.0.5",
+	}
+
+	SetTestEnvs(envs)
+
+	client, err := tfe.NewClient(&tfe.Config{
+		Address: fmt.Sprintf("https://%s", envs["terraform_host"]),
+		Token:   envs["terraform_token"],
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := RemoveTestWorkspaces(ctx, client, envs["terraform_organization"], "action-test"); err != nil {
+		t.Fatal(err)
+	}
+
+	ws, err := client.Workspaces.Create(ctx, envs["terraform_organization"], tfe.WorkspaceCreateOptions{
+		Name:             strPtr(envs["name"]),
+		TerraformVersion: strPtr("1.0.4"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, ws.TerraformVersion, "1.0.4")
+
 }

--- a/internal/action/main_test.go
+++ b/internal/action/main_test.go
@@ -33,36 +33,12 @@ func RemoveTestWorkspaces(ctx context.Context, client *tfe.Client, organization 
 	return nil
 }
 
-// func SetTestEnvs(envs map[string]string) {
-// 	for key, value := range envs {
-// 		os.Setenv(fmt.Sprintf("INPUT_%s", strings.ToUpper(key)), value)
-// 	}
-// }
-
-// func UnsetTestEnvs(envs map[string]string) {
-// 	for key := range envs {
-// 		os.Unsetenv(fmt.Sprintf("INPUT_%s", strings.ToUpper(key)))
-// 	}
-// }
-
 func TestCreateWorkspace(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
 
 	ctx := context.Background()
-
-	// envs := map[string]string{
-	// 	"terraform_token":          os.Getenv("tf_token"),
-	// 	"terraform_organization":   "ryanwholey",
-	// 	"terraform_host":           "app.terraform.io",
-	// 	"name":                     fmt.Sprintf("%s-%d", workspacePrefix, time.Now().Unix()),
-	// 	"import":                   "true",
-	// 	"apply":                    "true",
-	// 	"tfe_provider_version":     "0.25.3",
-	// 	"runner_terraform_version": "1.0.5",
-	// 	"terraform_version":        "1.0.5",
-	// }
 
 	config := &RunConfig{
 		Token:                  os.Getenv("tf_token"),
@@ -113,88 +89,84 @@ func TestCreateWorkspace(t *testing.T) {
 	})
 }
 
-// func TestImportExistingResources(t *testing.T) {
-// 	if testing.Short() {
-// 		t.Skip("skipping integration test")
-// 	}
+func TestImportExistingResources(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
 
-// 	ctx := context.Background()
+	ctx := context.Background()
 
-// 	envs := map[string]string{
-// 		"terraform_token":          os.Getenv("tf_token"),
-// 		"terraform_organization":   "ryanwholey",
-// 		"terraform_host":           "app.terraform.io",
-// 		"name":                     fmt.Sprintf("%s-%d", workspacePrefix, time.Now().Unix()),
-// 		"import":                   "true",
-// 		"apply":                    "true",
-// 		"tfe_provider_version":     "0.25.3",
-// 		"runner_terraform_version": "1.0.5",
-// 		"terraform_version":        "1.0.5",
-// 		"variables": `---
-// - key: foo
-//   value: baz
-//   category: terraform`,
-// 	}
+	config := &RunConfig{
+		Token:                  os.Getenv("tf_token"),
+		Organization:           "ryanwholey",
+		Host:                   "app.terraform.io",
+		Name:                   fmt.Sprintf("%s-%d", workspacePrefix, time.Now().Unix()),
+		Import:                 true,
+		Apply:                  true,
+		TFEProviderVersion:     "0.25.3",
+		RunnerTerraformVersion: "1.0.5",
+		TerraformVersion:       "1.0.5",
+		Variables: `---
+- key: foo
+  value: baz
+  category: terraform`,
+	}
 
-// 	SetTestEnvs(envs)
+	client, err := tfe.NewClient(&tfe.Config{
+		Address: fmt.Sprintf("https://%s", config.Host),
+		Token:   config.Token,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 
-// 	client, err := tfe.NewClient(&tfe.Config{
-// 		Address: fmt.Sprintf("https://%s", envs["terraform_host"]),
-// 		Token:   envs["terraform_token"],
-// 	})
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
+	if err := RemoveTestWorkspaces(ctx, client, config.Organization, workspacePrefix); err != nil {
+		t.Fatal(err)
+	}
 
-// 	if err := RemoveTestWorkspaces(ctx, client, envs["terraform_organization"], workspacePrefix); err != nil {
-// 		t.Fatal(err)
-// 	}
+	ws, err := client.Workspaces.Create(ctx, config.Organization, tfe.WorkspaceCreateOptions{
+		Name:             &config.Name,
+		TerraformVersion: strPtr("1.0.4"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 
-// 	ws, err := client.Workspaces.Create(ctx, envs["terraform_organization"], tfe.WorkspaceCreateOptions{
-// 		Name:             strPtr(envs["name"]),
-// 		TerraformVersion: strPtr("1.0.4"),
-// 	})
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
+	assert.Equal(t, ws.TerraformVersion, "1.0.4")
 
-// 	assert.Equal(t, ws.TerraformVersion, "1.0.4")
+	v, err := client.Variables.Create(ctx, ws.ID, tfe.VariableCreateOptions{
+		Key:      strPtr("foo"),
+		Value:    strPtr("bar"),
+		Category: tfe.Category(tfe.CategoryTerraform),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 
-// 	v, err := client.Variables.Create(ctx, ws.ID, tfe.VariableCreateOptions{
-// 		Key:      strPtr("foo"),
-// 		Value:    strPtr("bar"),
-// 		Category: tfe.Category(tfe.CategoryTerraform),
-// 	})
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
+	assert.Equal(t, v.Value, "bar")
 
-// 	assert.Equal(t, v.Value, "bar")
+	Run(config)
 
-// 	Run()
+	ws, err = client.Workspaces.Read(ctx, config.Organization, config.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-// 	ws, err = client.Workspaces.Read(ctx, envs["terraform_organization"], envs["name"])
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
+	assert.Equal(t, ws.TerraformVersion, "1.0.5")
 
-// 	assert.Equal(t, ws.TerraformVersion, "1.0.5")
+	v, err = client.Variables.Read(ctx, ws.ID, v.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-// 	v, err = client.Variables.Read(ctx, ws.ID, v.ID)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
+	assert.Equal(t, v.Value, "baz")
 
-// 	assert.Equal(t, v.Value, "baz")
-
-// 	t.Cleanup(func() {
-// 		UnsetTestEnvs(envs)
-
-// 		if err := RemoveTestWorkspaces(ctx, client, envs["terraform_organization"], workspacePrefix); err != nil {
-// 			t.Fatal(err)
-// 		}
-// 	})
-// }
+	t.Cleanup(func() {
+		if err := RemoveTestWorkspaces(ctx, client, config.Organization, workspacePrefix); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
 
 // func TestDriftCorrection(t *testing.T) {
 // 	if testing.Short() {

--- a/internal/action/main_test.go
+++ b/internal/action/main_test.go
@@ -43,6 +43,10 @@ func TestCreateWorkspace(t *testing.T) {
 	}
 
 	_, err = client.Workspaces.Read(ctx, envs["terraform_organization"], envs["name"])
+	if err != nil {
+		fmt.Println(envs["name"])
+		fmt.Println(err.Error())
+	}
 	if err.Error() != "resource not found" {
 		t.Fatal("test workspace already exists")
 	}

--- a/internal/action/main_test.go
+++ b/internal/action/main_test.go
@@ -324,6 +324,15 @@ production:
 
 	assert.Equal(t, len(ws.Items), 2)
 
+	for _, ws := range ws.Items {
+		v, err := client.Variables.List(ctx, ws.ID, tfe.VariableListOptions{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Equal(t, len(v.Items), 1)
+	}
+
 	t.Cleanup(func() {
 		UnsetTestEnvs(envs)
 

--- a/internal/action/team_access.go
+++ b/internal/action/team_access.go
@@ -95,7 +95,7 @@ func FindRelatedTeamAccess(ctx context.Context, client *tfe.Client, workspace *W
 
 	tas, err := client.TeamAccess.List(ctx, tfe.TeamAccessListOptions{
 		ListOptions: tfe.ListOptions{
-			PageSize: 100,
+			PageSize: maxPageSize,
 		},
 		WorkspaceID: workspace.ID,
 	})

--- a/internal/action/team_access.go
+++ b/internal/action/team_access.go
@@ -105,7 +105,7 @@ func FindRelatedTeamAccess(ctx context.Context, client *tfe.Client, workspace *W
 
 	teams, err := client.Teams.List(ctx, organization, tfe.TeamListOptions{
 		ListOptions: tfe.ListOptions{
-			PageSize: 100,
+			PageSize: maxPageSize,
 		},
 	})
 	if err != nil {

--- a/internal/action/variable.go
+++ b/internal/action/variable.go
@@ -74,7 +74,7 @@ func FindRelatedVariables(ctx context.Context, client *tfe.Client, workspace *Wo
 
 	tfVars, err := client.Variables.List(ctx, *workspace.ID, tfe.VariableListOptions{
 		ListOptions: tfe.ListOptions{
-			PageSize: 100,
+			PageSize: maxPageSize,
 		},
 	})
 	if err != nil {

--- a/internal/action/workspace.go
+++ b/internal/action/workspace.go
@@ -3,6 +3,7 @@ package action
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"strings"
@@ -24,7 +25,7 @@ type Workspace struct {
 func getVCSClientByName(ctx context.Context, tfc *tfe.Client, organization string, vcsType string) (*tfe.OAuthClient, error) {
 	list, err := tfc.OAuthClients.List(ctx, organization, tfe.OAuthClientListOptions{
 		ListOptions: tfe.ListOptions{
-			PageSize: 100,
+			PageSize: maxPageSize,
 		},
 	})
 	if err != nil {
@@ -350,7 +351,7 @@ func SetWorkspaceIDs(ctx context.Context, client *tfe.Client, workspaces []*Work
 	for _, workspace := range workspaces {
 		ws, err := client.Workspaces.Read(ctx, organization, workspace.Name)
 		if err != nil {
-			if err.Error() != "resource not found" {
+			if !errors.Is(err, tfe.ErrResourceNotFound) {
 				return err
 			}
 		} else {

--- a/main.go
+++ b/main.go
@@ -1,7 +1,44 @@
 package main
 
-import "github.com/takescoop/terraform-cloud-workspace-action/internal/action"
+import (
+	"strings"
+
+	"github.com/sethvargo/go-githubactions"
+	"github.com/takescoop/terraform-cloud-workspace-action/internal/action"
+	"github.com/takescoop/terraform-cloud-workspace-action/internal/action/inputs"
+)
 
 func main() {
-	action.Run()
+	action.Run(&action.RunConfig{
+		Token:                  githubactions.GetInput("terraform_token"),
+		Host:                   githubactions.GetInput("terraform_host"),
+		Name:                   strings.TrimSpace(githubactions.GetInput("name")),
+		Organization:           githubactions.GetInput("terraform_organization"),
+		Apply:                  inputs.GetBool("apply"),
+		RunnerTerraformVersion: githubactions.GetInput("runner_terraform_version"),
+		RemoteStates:           githubactions.GetInput("remote_states"),
+		Workspaces:             githubactions.GetInput("workspaces"),
+		Variables:              githubactions.GetInput("variables"),
+		WorkspaceVariables:     githubactions.GetInput("workspace_variables"),
+		TeamAccess:             githubactions.GetInput("team_access"),
+		BackendConfig:          githubactions.GetInput("backend_config"),
+		AgentPoolID:            githubactions.GetInput("agent_pool_id"),
+		AutoApply:              inputs.GetBoolPtr("auto_apply"),
+		ExecutionMode:          githubactions.GetInput("execution_mode"),
+		FileTriggersEnabled:    inputs.GetBoolPtr("file_triggers_enabled"),
+		GlobalRemoteState:      inputs.GetBoolPtr("global_remote_state"),
+		QueueAllRuns:           inputs.GetBoolPtr("queue_all_runs"),
+		RemoteStateConsumerIDs: githubactions.GetInput("remote_state_consumer_ids"),
+		SpeculativeEnabled:     inputs.GetBoolPtr("speculative_enabled"),
+		TerraformVersion:       githubactions.GetInput("terraform_version"),
+		SSHKeyID:               githubactions.GetInput("ssh_key_id"),
+		VCSIngressSubmodules:   inputs.GetBool("vcs_ingress_submodules"),
+		VCSRepo:                githubactions.GetInput("vcs_repo"),
+		VCSTokenID:             githubactions.GetInput("vcs_token_id"),
+		VCSType:                githubactions.GetInput("vcs_type"),
+		WorkingDirectory:       githubactions.GetInput("working_directory"),
+		TFEProviderVersion:     githubactions.GetInput("tfe_provider_version"),
+		Import:                 inputs.GetBool("import"),
+		AllowWorkspaceDeletion: inputs.GetBool("allow_workspace_deletion"),
+	})
 }

--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 func main() {
-	action.Run(&action.RunConfig{
+	if err := action.Run(&action.Inputs{
 		Token:                  githubactions.GetInput("terraform_token"),
 		Host:                   githubactions.GetInput("terraform_host"),
 		Name:                   strings.TrimSpace(githubactions.GetInput("name")),
@@ -40,5 +40,7 @@ func main() {
 		TFEProviderVersion:     githubactions.GetInput("tfe_provider_version"),
 		Import:                 inputs.GetBool("import"),
 		AllowWorkspaceDeletion: inputs.GetBool("allow_workspace_deletion"),
-	})
+	}); err != nil {
+		githubactions.Fatalf("Error: %s", err)
+	}
 }


### PR DESCRIPTION
Adds 4 tests, ran when `-short` is not passed:
1) Basic workspace creation
2) Import a workspace and supporting resources
3) Drift correction
4) Multiple workspaces