### PR TITLE
Pass providers to import

### DIFF
--- a/internal/action/import.go
+++ b/internal/action/import.go
@@ -216,7 +216,7 @@ func ImportTeamAccess(ctx context.Context, tf TerraformCLI, client *tfe.Client, 
 }
 
 // ImportWorkspaceResources discovers and imports resources related to the passed workspace
-func ImportWorkspaceResources(ctx context.Context, client *tfe.Client, tf *tfexec.Terraform, filePath string, workspace *Workspace, organization string) error {
+func ImportWorkspaceResources(ctx context.Context, client *tfe.Client, tf *tfexec.Terraform, filePath string, workspace *Workspace, organization string, providers []Provider) error {
 	module := NewModule()
 
 	wsConfig, err := NewWorkspaceResource(ctx, client, []*Workspace{workspace}, &WorkspaceResourceOptions{})
@@ -241,6 +241,8 @@ func ImportWorkspaceResources(ctx context.Context, client *tfe.Client, tf *tfexe
 	}
 
 	AppendTeamAccess(module, teamAccess, organization)
+
+	AddProviders(module, providers)
 
 	if err := WriteModuleFile(module, filePath); err != nil {
 		return err
@@ -267,9 +269,9 @@ func ImportWorkspaceResources(ctx context.Context, client *tfe.Client, tf *tfexe
 }
 
 // ImportResources discovers and imports resources related to the passed workspaces
-func ImportResources(ctx context.Context, client *tfe.Client, tf *tfexec.Terraform, module *tfconfig.Module, filePath string, workspaces []*Workspace, organization string) error {
+func ImportResources(ctx context.Context, client *tfe.Client, tf *tfexec.Terraform, module *tfconfig.Module, filePath string, workspaces []*Workspace, organization string, providers []Provider) error {
 	for _, ws := range workspaces {
-		if err := ImportWorkspaceResources(ctx, client, tf, filePath, ws, organization); err != nil {
+		if err := ImportWorkspaceResources(ctx, client, tf, filePath, ws, organization, providers); err != nil {
 			return err
 		}
 	}

--- a/internal/action/main.go
+++ b/internal/action/main.go
@@ -136,6 +136,18 @@ func Run() {
 		githubactions.Fatalf("Failed to parse backend configuration: %s", err)
 	}
 
+	providers := []Provider{
+		{
+			Name:    "tfe",
+			Version: githubactions.GetInput("tfe_provider_version"),
+			Source:  "hashicorp/tfe",
+			Config: tfeprovider.Config{
+				Hostname: host,
+				Token:    token,
+			},
+		},
+	}
+
 	module, err := NewWorkspaceConfig(ctx, client, workspaces, &NewWorkspaceConfigOptions{
 		Backend: backend,
 		WorkspaceResourceOptions: &WorkspaceResourceOptions{
@@ -159,17 +171,7 @@ func Run() {
 		RemoteStates: remoteStates,
 		Variables:    variables,
 		TeamAccess:   teamAccess,
-		Providers: []Provider{
-			{
-				Name:    "tfe",
-				Version: githubactions.GetInput("tfe_provider_version"),
-				Source:  "hashicorp/tfe",
-				Config: tfeprovider.Config{
-					Hostname: host,
-					Token:    token,
-				},
-			},
-		},
+		Providers:    providers,
 	})
 	if err != nil {
 		githubactions.Fatalf("Failed to create new workspace configuration: %s", err)
@@ -186,7 +188,7 @@ func Run() {
 	}
 
 	if inputs.GetBool("import") {
-		if err = ImportResources(ctx, client, tf, module, filePath, workspaces, org); err != nil {
+		if err = ImportResources(ctx, client, tf, module, filePath, workspaces, org, providers); err != nil {
 			githubactions.Fatalf("Failed to import resources: %s", err)
 		}
 	}

--- a/internal/action/team_access.go
+++ b/internal/action/team_access.go
@@ -2,6 +2,7 @@ package action
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	tfe "github.com/hashicorp/go-tfe"
@@ -100,6 +101,13 @@ func FindRelatedTeamAccess(ctx context.Context, client *tfe.Client, workspace *W
 	var access TeamAccess
 
 	for _, ta := range tas.Items {
+		b, err := json.MarshalIndent(ta, "", "  ")
+		if err != nil {
+			return nil, err
+		}
+
+		fmt.Println(string(b))
+
 		item := TeamAccessItem{
 			Workspace: workspace,
 			Access:    string(ta.Access),

--- a/internal/action/team_access.go
+++ b/internal/action/team_access.go
@@ -2,6 +2,7 @@ package action
 
 import (
 	"context"
+	"fmt"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/takescoop/terraform-cloud-workspace-action/internal/tfeprovider"
@@ -78,8 +79,11 @@ type TeamAccessPermissionsInput struct {
 // FindRelatedTeamAccess returns a list of workspace related team access resources
 func FindRelatedTeamAccess(ctx context.Context, client *tfe.Client, workspace *Workspace, organization string) (TeamAccess, error) {
 	if workspace.ID == nil {
+		fmt.Println("no WS ID found")
 		return TeamAccess{}, nil
 	}
+
+	fmt.Printf("ws ID: %s\n", *workspace.ID)
 
 	tas, err := client.TeamAccess.List(ctx, tfe.TeamAccessListOptions{
 		ListOptions: tfe.ListOptions{
@@ -90,6 +94,8 @@ func FindRelatedTeamAccess(ctx context.Context, client *tfe.Client, workspace *W
 	if err != nil {
 		return nil, err
 	}
+
+	fmt.Println("related team access", tas)
 
 	var access TeamAccess
 

--- a/internal/action/team_access_test.go
+++ b/internal/action/team_access_test.go
@@ -84,7 +84,6 @@ func TestNewTeamAccess(t *testing.T) {
 }
 
 func TestFindRelatedTeamAccess(t *testing.T) {
-
 	t.Run("team access found", func(t *testing.T) {
 		ctx := context.Background()
 

--- a/internal/action/team_access_test.go
+++ b/internal/action/team_access_test.go
@@ -1,6 +1,9 @@
 package action
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -78,4 +81,62 @@ func TestNewTeamAccess(t *testing.T) {
 			assert.Equal(t, access, testCase.Expect)
 		})
 	}
+}
+
+func TestFindRelatedTeamAccess(t *testing.T) {
+
+	t.Run("team access found", func(t *testing.T) {
+		ctx := context.Background()
+
+		mux := http.NewServeMux()
+		server := httptest.NewServer(mux)
+
+		t.Cleanup(func() {
+			server.Close()
+		})
+
+		mux.HandleFunc("/api/v2/organizations/org/teams", testServerResHandler(t, 200, teamAPIResponse))
+		mux.HandleFunc("/api/v2/team-workspaces", testServerResHandler(t, 200, teamAccessAPIResponse))
+
+		client := newTestTFClient(t, server.URL)
+
+		workspace := &Workspace{Name: "ws", Workspace: "default", ID: strPtr("ws-abc123")}
+		access, err := FindRelatedTeamAccess(ctx, client, workspace, "org")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Equal(t, len(access), 1)
+		assert.Equal(t, access, TeamAccess{
+			{
+				TeamName:  "Readers",
+				Access:    "write",
+				Workspace: workspace,
+			},
+		})
+	})
+
+	t.Run("no team access found", func(t *testing.T) {
+		ctx := context.Background()
+
+		mux := http.NewServeMux()
+		server := httptest.NewServer(mux)
+
+		t.Cleanup(func() {
+			server.Close()
+		})
+
+		mux.HandleFunc("/api/v2/organizations/org/teams", testServerResHandler(t, 200, `{"data": []}`))
+		mux.HandleFunc("/api/v2/team-workspaces", testServerResHandler(t, 200, `{"data": []}`))
+
+		client := newTestTFClient(t, server.URL)
+
+		workspace := &Workspace{Name: "ws", Workspace: "default", ID: strPtr("ws-abc123")}
+		access, err := FindRelatedTeamAccess(ctx, client, workspace, "org")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Equal(t, len(access), 0)
+	})
 }

--- a/internal/action/workspace.go
+++ b/internal/action/workspace.go
@@ -258,8 +258,6 @@ func WriteModuleFile(module *tfconfig.Module, filePath string) error {
 		return err
 	}
 
-	fmt.Println(string(b))
-
 	if err = ioutil.WriteFile(filePath, b, 0644); err != nil {
 		return err
 	}

--- a/internal/action/workspace.go
+++ b/internal/action/workspace.go
@@ -258,6 +258,8 @@ func WriteModuleFile(module *tfconfig.Module, filePath string) error {
 		return err
 	}
 
+	fmt.Println(string(b))
+
 	if err = ioutil.WriteFile(filePath, b, 0644); err != nil {
 		return err
 	}


### PR DESCRIPTION
I was testing the drift detection out against a Scoop workspace ([test-workspace](https://terraform.takescoop.com/app/takescoop/workspaces/test-workspace/runs)) and ran into a couple bugs which differ slightly from testing against TFC. 

For one, the free plan doesnt support teams so there was a bug importing teams that I missed. The team name isn't returned in the API response, only the team ID. This seems like the go TFE client should support an `include` statement like some of the other resources, but in this case it doesn't at the moment, and an easy workaround is just to fetch the teams first, then find the team name by matching IDs. Looking into the opportunity for an upstream PR. Update: looks like the API [team-workspaces](https://www.terraform.io/docs/cloud/api/team-access.html) API currently doesn't support an include.

The second, import functionality needs the correct TF host in the provider or else it will target `app.terraform.io` by default, so providers are now passed to the import function.

