### PR TITLE
Add workspace description support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ jobs:
 | `agent_pool_id` | ID of an agent pool to assign to the workspace. If passed, execution_mode is set to "agent" | |
 | `auto_apply` | Whether to set auto_apply on the workspace or workspaces | true |
 | `backend_config` | YAML encoded backend configurations | |
+| `description` | Terraform Cloud workspace description | |
 | `execution_mode` | Execution mode to use for the workspace | |
 | `file_triggers_enabled` | Whether to filter runs based on the changed files in a VCS push | |
 | `global_remote_state` | Whether all workspaces in the organization can access the workspace via remote state | `false` |

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ jobs:
 | `agent_pool_id` | ID of an agent pool to assign to the workspace. If passed, execution_mode is set to "agent" | |
 | `auto_apply` | Whether to set auto_apply on the workspace or workspaces | true |
 | `backend_config` | YAML encoded backend configurations | |
-| `description` | Terraform Cloud workspace description | |
+| `description` | Terraform Cloud workspace description | `${{ github.event.repository.description}}` |
 | `execution_mode` | Execution mode to use for the workspace | |
 | `file_triggers_enabled` | Whether to filter runs based on the changed files in a VCS push | |
 | `global_remote_state` | Whether all workspaces in the organization can access the workspace via remote state | `false` |

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,8 @@ inputs:
   name:
     description: Name of the workspace. Becomes a prefix if workspaces are passed (`${name}-${workspace}`).
     default: "${{ github.event.repository.name }}"
+  description:
+    description: Terraform Cloud workspace description
   runner_terraform_version:
     description: Terraform version used to create the workspace.
     default: "1.0.3"

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,7 @@ inputs:
     default: "${{ github.event.repository.name }}"
   description:
     description: Terraform Cloud workspace description
+    default: "${{ github.event.repository.description }}"
   tags:
     description: YAML encoded list of tag names applied to all workspaces
     default: ""

--- a/internal/action/main.go
+++ b/internal/action/main.go
@@ -20,6 +20,7 @@ type Inputs struct {
 	Token                  string
 	Host                   string
 	Name                   string
+	Description            string
 	Organization           string
 	Apply                  bool
 	RunnerTerraformVersion string
@@ -178,6 +179,7 @@ func Run(config *Inputs) error {
 		WorkspaceResourceOptions: &WorkspaceResourceOptions{
 			AgentPoolID:            config.AgentPoolID,
 			AutoApply:              config.AutoApply,
+			Description:            config.Description,
 			ExecutionMode:          config.ExecutionMode,
 			FileTriggersEnabled:    config.FileTriggersEnabled,
 			GlobalRemoteState:      config.GlobalRemoteState,

--- a/internal/action/workspace.go
+++ b/internal/action/workspace.go
@@ -58,6 +58,7 @@ func GetVCSTokenIDByClientType(ctx context.Context, tfc *tfe.Client, organizatio
 type WorkspaceResourceOptions struct {
 	AgentPoolID            string
 	AutoApply              *bool
+	Description            string
 	ExecutionMode          string
 	FileTriggersEnabled    *bool
 	GlobalRemoteState      *bool
@@ -136,6 +137,7 @@ func NewWorkspaceResource(ctx context.Context, client *tfe.Client, workspaces []
 		}
 	}
 
+	ws.Description = config.Description
 	ws.TerraformVersion = config.TerraformVersion
 	ws.QueueAllRuns = config.QueueAllRuns
 	ws.SpeculativeEnabled = config.SpeculativeEnabled

--- a/internal/action/workspace_test.go
+++ b/internal/action/workspace_test.go
@@ -307,6 +307,18 @@ func TestNewWorkspaceResource(t *testing.T) {
 		assert.Equal(t, *ws.GlobalRemoteState, false)
 		assert.Equal(t, ws.RemoteStateConsumerIDs, []string{})
 	})
+
+	t.Run("add a description if passed", func(t *testing.T) {
+		ws, err := NewWorkspaceResource(ctx, client, []*Workspace{{Name: "foo"}}, &WorkspaceResourceOptions{
+			Organization: "org",
+			Description:  "description",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Equal(t, ws.Description, "description")
+	})
 }
 
 func TestAppendTeamAccess(t *testing.T) {

--- a/internal/tfeprovider/workspace.go
+++ b/internal/tfeprovider/workspace.go
@@ -5,6 +5,7 @@ type Workspace struct {
 
 	AgentPoolID            string   `json:"agent_pool_id,omitempty"`
 	AutoApply              *bool    `json:"auto_apply,omitempty"`
+	Description            string   `json:"description,omitempty"`
 	ExecutionMode          string   `json:"execution_mode,omitempty"`
 	FileTriggersEnabled    *bool    `json:"file_triggers_enabled,omitempty"`
 	GlobalRemoteState      *bool    `json:"global_remote_state,omitempty"`

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ func main() {
 		Token:                  githubactions.GetInput("terraform_token"),
 		Host:                   githubactions.GetInput("terraform_host"),
 		Name:                   strings.TrimSpace(githubactions.GetInput("name")),
+		Description:            githubactions.GetInput("description"),
 		Organization:           githubactions.GetInput("terraform_organization"),
 		Apply:                  inputs.GetBool("apply"),
 		RunnerTerraformVersion: githubactions.GetInput("runner_terraform_version"),


### PR DESCRIPTION
Adds support for the workspace [description](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/workspace#description) attribute, defaults to the repository description

fixes #77 