### PR TITLE
Use workspace shortname in resource address

### DIFF
--- a/internal/action/import.go
+++ b/internal/action/import.go
@@ -232,7 +232,7 @@ func ImportWorkspaceResources(ctx context.Context, client *tfe.Client, tf *tfexe
 	}
 
 	for _, v := range variables {
-		module.AppendResource("tfe_variable", fmt.Sprintf("%s-%s", v.Workspace.Name, v.Key), v.ToResource())
+		module.AppendResource("tfe_variable", fmt.Sprintf("%s-%s", v.Workspace.Workspace, v.Key), v.ToResource())
 	}
 
 	teamAccess, err := FindRelatedTeamAccess(ctx, client, workspace, organization)

--- a/internal/action/import.go
+++ b/internal/action/import.go
@@ -98,7 +98,7 @@ func ImportVariable(ctx context.Context, tf TerraformCLI, client *tfe.Client, ke
 		return nil
 	}
 
-	address := fmt.Sprintf("tfe_variable.%s-%s", workspace.Name, key)
+	address := fmt.Sprintf("tfe_variable.%s-%s", workspace.Workspace, key)
 
 	imp, err := shouldImport(ctx, tf, address)
 	if err != nil {
@@ -170,7 +170,7 @@ func ImportTeamAccess(ctx context.Context, tf TerraformCLI, client *tfe.Client, 
 		return fmt.Errorf("team %q not found", teamName)
 	}
 
-	address := fmt.Sprintf("tfe_team_access.teams[\"%s-%s\"]", workspace.Name, team.ID)
+	address := fmt.Sprintf("tfe_team_access.teams[\"%s-%s\"]", workspace.Workspace, team.ID)
 
 	imp, err := shouldImport(ctx, tf, address)
 	if err != nil {

--- a/internal/action/import.go
+++ b/internal/action/import.go
@@ -44,7 +44,7 @@ func ImportWorkspace(ctx context.Context, tf TerraformCLI, client *tfe.Client, w
 		return nil
 	}
 
-	address := fmt.Sprintf("tfe_workspace.workspace[%q]", workspace.Name)
+	address := fmt.Sprintf("tfe_workspace.workspace[%q]", workspace.Workspace)
 
 	imp, err := shouldImport(ctx, tf, address)
 	if err != nil {

--- a/internal/action/import_test.go
+++ b/internal/action/import_test.go
@@ -123,20 +123,20 @@ func TestImportVariable(t *testing.T) {
 				Values: &tfjson.StateValues{
 					RootModule: &tfjson.StateModule{
 						Resources: []*tfjson.StateResource{
-							{Address: "tfe_workspace.workspace[\"ws\"]"},
+							{Address: "tfe_workspace.workspace[\"default\"]"},
 						},
 					},
 				},
 			},
 		}
 
-		if err := ImportVariable(ctx, &tf, client, "foo", &Workspace{Name: "ws", ID: strPtr("ws-abc123")}, "org"); err != nil {
+		if err := ImportVariable(ctx, &tf, client, "foo", &Workspace{Name: "ws", Workspace: "default", ID: strPtr("ws-abc123")}, "org"); err != nil {
 			t.Fatal(err)
 		}
 
 		assert.Equal(t, len(tf.ImportArgs), 1)
 		assert.Equal(t, tf.ImportArgs[0], &ImportArgs{
-			Address: "tfe_variable.ws-foo",
+			Address: "tfe_variable.default-foo",
 			ID:      "org/ws/var-abc123",
 			Opts:    ([]tfexec.ImportOption)(nil),
 		})
@@ -184,14 +184,14 @@ func TestImportVariable(t *testing.T) {
 				Values: &tfjson.StateValues{
 					RootModule: &tfjson.StateModule{
 						Resources: []*tfjson.StateResource{
-							{Address: "tfe_workspace.workspace[\"ws\"]"},
+							{Address: "tfe_workspace.workspace[\"default\"]"},
 						},
 					},
 				},
 			},
 		}
 
-		if err := ImportVariable(ctx, &tf, client, "foo", &Workspace{Name: "ws", ID: strPtr("ws-abc123")}, "org"); err != nil {
+		if err := ImportVariable(ctx, &tf, client, "foo", &Workspace{Name: "ws", Workspace: "default", ID: strPtr("ws-abc123")}, "org"); err != nil {
 			t.Fatal(err)
 		}
 
@@ -220,20 +220,20 @@ func TestImportTeamAccess(t *testing.T) {
 				Values: &tfjson.StateValues{
 					RootModule: &tfjson.StateModule{
 						Resources: []*tfjson.StateResource{
-							{Address: "tfe_workspace.workspace[\"ws\"]"},
+							{Address: "tfe_workspace.workspace[\"default\"]"},
 						},
 					},
 				},
 			},
 		}
 
-		if err := ImportTeamAccess(ctx, &tf, client, "org", &Workspace{Name: "ws", ID: strPtr("ws-abc123")}, "Readers"); err != nil {
+		if err := ImportTeamAccess(ctx, &tf, client, "org", &Workspace{Name: "ws", Workspace: "default", ID: strPtr("ws-abc123")}, "Readers"); err != nil {
 			t.Fatal(err)
 		}
 
 		assert.Equal(t, len(tf.ImportArgs), 1)
 		assert.Equal(t, tf.ImportArgs[0], &ImportArgs{
-			Address: "tfe_team_access.teams[\"ws-team-abc123\"]",
+			Address: "tfe_team_access.teams[\"default-team-abc123\"]",
 			ID:      "org/ws/tws-abc213",
 			Opts:    ([]tfexec.ImportOption)(nil),
 		})
@@ -279,15 +279,15 @@ func TestImportTeamAccess(t *testing.T) {
 				Values: &tfjson.StateValues{
 					RootModule: &tfjson.StateModule{
 						Resources: []*tfjson.StateResource{
-							{Address: "tfe_workspace.workspace[\"ws\"]"},
-							{Address: "tfe_team_access.teams[\"ws-team-abc123\"]"},
+							{Address: "tfe_workspace.workspace[\"default\"]"},
+							{Address: "tfe_team_access.teams[\"default-team-abc123\"]"},
 						},
 					},
 				},
 			},
 		}
 
-		if err := ImportTeamAccess(ctx, &tf, client, "org", &Workspace{Name: "ws", ID: strPtr("ws-abc123")}, "Readers"); err != nil {
+		if err := ImportTeamAccess(ctx, &tf, client, "org", &Workspace{Name: "ws", Workspace: "default", ID: strPtr("ws-abc123")}, "Readers"); err != nil {
 			t.Fatal(err)
 		}
 
@@ -312,14 +312,14 @@ func TestImportTeamAccess(t *testing.T) {
 				Values: &tfjson.StateValues{
 					RootModule: &tfjson.StateModule{
 						Resources: []*tfjson.StateResource{
-							{Address: "tfe_workspace.workspace[\"ws\"]"},
+							{Address: "tfe_workspace.workspace[\"default\"]"},
 						},
 					},
 				},
 			},
 		}
 
-		if err := ImportTeamAccess(ctx, &tf, client, "org", &Workspace{Name: "ws", ID: strPtr("ws-abc123")}, "Readers"); err != nil {
+		if err := ImportTeamAccess(ctx, &tf, client, "org", &Workspace{Name: "ws", Workspace: "default", ID: strPtr("ws-abc123")}, "Readers"); err != nil {
 			t.Fatal(err)
 		}
 

--- a/internal/action/import_test.go
+++ b/internal/action/import_test.go
@@ -58,14 +58,14 @@ func TestImportWorkspace(t *testing.T) {
 				Values: &tfjson.StateValues{
 					RootModule: &tfjson.StateModule{
 						Resources: []*tfjson.StateResource{
-							{Address: "tfe_workspace.workspace[\"ws\"]"},
+							{Address: "tfe_workspace.workspace[\"default\"]"},
 						},
 					},
 				},
 			},
 		}
 
-		if err := ImportWorkspace(ctx, &tf, client, &Workspace{Name: "ws", ID: strPtr("ws-abc123")}, "org"); err != nil {
+		if err := ImportWorkspace(ctx, &tf, client, &Workspace{Name: "ws", Workspace: "default", ID: strPtr("ws-abc123")}, "org"); err != nil {
 			t.Fatal(err)
 		}
 
@@ -77,13 +77,13 @@ func TestImportWorkspace(t *testing.T) {
 			State: &tfjson.State{},
 		}
 
-		if err := ImportWorkspace(ctx, &tf, client, &Workspace{Name: "ws", ID: strPtr("ws-abc123")}, "org"); err != nil {
+		if err := ImportWorkspace(ctx, &tf, client, &Workspace{Name: "ws", Workspace: "default", ID: strPtr("ws-abc123")}, "org"); err != nil {
 			t.Fatal(err)
 		}
 
 		assert.Equal(t, len(tf.ImportArgs), 1)
 		assert.Equal(t, tf.ImportArgs[0], &ImportArgs{
-			Address: "tfe_workspace.workspace[\"ws\"]",
+			Address: "tfe_workspace.workspace[\"default\"]",
 			ID:      "ws-abc123",
 			Opts:    ([]tfexec.ImportOption)(nil),
 		})
@@ -94,7 +94,7 @@ func TestImportWorkspace(t *testing.T) {
 			State: &tfjson.State{},
 		}
 
-		if err := ImportWorkspace(ctx, &tf, client, &Workspace{Name: "ws", ID: nil}, "org"); err != nil {
+		if err := ImportWorkspace(ctx, &tf, client, &Workspace{Name: "ws", Workspace: "default", ID: nil}, "org"); err != nil {
 			t.Fatal(err)
 		}
 

--- a/internal/action/variable.go
+++ b/internal/action/variable.go
@@ -51,7 +51,7 @@ func (v Variable) ToResource() *tfeprovider.Variable {
 		Description: v.Description,
 		Category:    v.Category,
 		Sensitive:   v.Sensitive,
-		WorkspaceID: fmt.Sprintf("${tfe_workspace.workspace[%q].id}", v.Workspace.Name),
+		WorkspaceID: fmt.Sprintf("${tfe_workspace.workspace[%q].id}", v.Workspace.Workspace),
 	}
 }
 

--- a/internal/action/workspace.go
+++ b/internal/action/workspace.go
@@ -188,12 +188,8 @@ func SetTags(module *tfeprovider.Workspace, tags map[string]Tags) error {
 func MergeWorkspaceTags(tags Tags, wsTags map[string]Tags, workspaces []*Workspace) (map[string]Tags, error) {
 	tagsByWorkspace := map[string]Tags{}
 
-	// if len(tags) == 0 && len(wsTags) == 0 {
-	// 	return tagsByWorkspace, nil
-	// }
-
 	for _, ws := range workspaces {
-		tagsByWorkspace[ws.Name] = append(Tags{}, tags...)
+		tagsByWorkspace[ws.Workspace] = append(Tags{}, tags...)
 	}
 
 	for wsName, ts := range wsTags {
@@ -202,7 +198,7 @@ func MergeWorkspaceTags(tags Tags, wsTags map[string]Tags, workspaces []*Workspa
 			return nil, fmt.Errorf("tags specified for unknown workspace %q", wsName)
 		}
 
-		tagsByWorkspace[ws.Name] = append(tagsByWorkspace[ws.Name], ts...)
+		tagsByWorkspace[ws.Workspace] = append(tagsByWorkspace[ws.Workspace], ts...)
 	}
 
 	return tagsByWorkspace, nil
@@ -225,7 +221,7 @@ func AppendTeamAccess(module *tfconfig.Module, teamAccess TeamAccess, organizati
 
 		teamIDRef := fmt.Sprintf("${data.tfe_team.teams[\"%s\"].id}", access.TeamName)
 
-		resourceForEach[fmt.Sprintf("%s-%s", access.Workspace.Name, teamIDRef)] = tfeprovider.TeamAccess{
+		resourceForEach[fmt.Sprintf("%s-%s", access.Workspace.Workspace, teamIDRef)] = tfeprovider.TeamAccess{
 			TeamID:      teamIDRef,
 			WorkspaceID: fmt.Sprintf("${tfe_workspace.workspace[%q].id}", access.Workspace.Workspace),
 			Access:      access.Access,
@@ -298,7 +294,7 @@ func NewWorkspaceConfig(ctx context.Context, client *tfe.Client, workspaces []*W
 	}
 
 	for _, v := range config.Variables {
-		module.AppendResource("tfe_variable", fmt.Sprintf("%s-%s", v.Workspace.Name, v.Key), v.ToResource())
+		module.AppendResource("tfe_variable", fmt.Sprintf("%s-%s", v.Workspace.Workspace, v.Key), v.ToResource())
 	}
 
 	AppendTeamAccess(module, config.TeamAccess, wsResource.Organization)

--- a/internal/action/workspace.go
+++ b/internal/action/workspace.go
@@ -179,7 +179,7 @@ func SetTags(module *tfeprovider.Workspace, tags map[string]Tags) error {
 		return fmt.Errorf("failed to marshal workspace tags: %w", err)
 	}
 
-	module.TagNames = fmt.Sprintf("${toset(lookup(%s, each.value.name, []))}", string(b))
+	module.TagNames = fmt.Sprintf("${toset(lookup(%s, each.key, []))}", string(b))
 
 	return nil
 }

--- a/internal/action/workspace.go
+++ b/internal/action/workspace.go
@@ -81,7 +81,7 @@ func NewWorkspaceResource(ctx context.Context, client *tfe.Client, workspaces []
 	wsForEach := map[string]*tfeprovider.Workspace{}
 
 	for _, ws := range workspaces {
-		wsForEach[ws.Name] = &tfeprovider.Workspace{
+		wsForEach[ws.Workspace] = &tfeprovider.Workspace{
 			Name: ws.Name,
 		}
 	}
@@ -227,7 +227,7 @@ func AppendTeamAccess(module *tfconfig.Module, teamAccess TeamAccess, organizati
 
 		resourceForEach[fmt.Sprintf("%s-%s", access.Workspace.Name, teamIDRef)] = tfeprovider.TeamAccess{
 			TeamID:      teamIDRef,
-			WorkspaceID: fmt.Sprintf("${tfe_workspace.workspace[%q].id}", access.Workspace.Name),
+			WorkspaceID: fmt.Sprintf("${tfe_workspace.workspace[%q].id}", access.Workspace.Workspace),
 			Access:      access.Access,
 			Permissions: access.ToResource().Permissions,
 		}

--- a/internal/action/workspace_test.go
+++ b/internal/action/workspace_test.go
@@ -3,7 +3,6 @@ package action
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -484,8 +483,6 @@ func RunValidate(ctx context.Context, name string, tfexecPath string, module *tf
 	if err != nil {
 		return nil, err
 	}
-
-	fmt.Println(string(b))
 
 	if err = ioutil.WriteFile(path.Join(workDir, "main.tf.json"), b, 0644); err != nil {
 		return nil, err

--- a/internal/action/workspace_test.go
+++ b/internal/action/workspace_test.go
@@ -365,7 +365,7 @@ func TestNewWorkspaceResourceWithTags(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		assert.Equal(t, "${toset(lookup({\"production\":[\"all\",\"production\"],\"staging\":[\"all\",\"staging\"]}, each.value.name, []))}", ws.TagNames)
+		assert.Equal(t, "${toset(lookup({\"production\":[\"all\",\"production\"],\"staging\":[\"all\",\"staging\"]}, each.key, []))}", ws.TagNames)
 	})
 }
 

--- a/internal/action/workspace_test.go
+++ b/internal/action/workspace_test.go
@@ -141,7 +141,7 @@ func TestNewWorkspaceResource(t *testing.T) {
 
 	t.Run("should render a basic workspace without unprovided values", func(t *testing.T) {
 		ws, err := NewWorkspaceResource(ctx, client, []*Workspace{
-			{Name: "foo"},
+			{Name: "foo", Workspace: "default"},
 		}, &WorkspaceResourceOptions{
 			Organization: "org",
 		})
@@ -157,7 +157,7 @@ func TestNewWorkspaceResource(t *testing.T) {
 
 		assert.Equal(t, string(s), `{
 	"for_each": {
-		"foo": {
+		"default": {
 			"name": "foo"
 		}
 	},
@@ -357,8 +357,8 @@ func TestAppendTeamAccess(t *testing.T) {
 		module := NewModule()
 
 		AppendTeamAccess(module, TeamAccess{
-			TeamAccessItem{TeamName: "Readers", Access: "read", Workspace: &Workspace{Name: "workspace"}},
-			TeamAccessItem{TeamName: "Writers", Access: "write", Workspace: &Workspace{Name: "workspace"}},
+			TeamAccessItem{TeamName: "Readers", Access: "read", Workspace: &Workspace{Name: "workspace", Workspace: "default"}},
+			TeamAccessItem{TeamName: "Writers", Access: "write", Workspace: &Workspace{Name: "workspace", Workspace: "default"}},
 		}, "org")
 
 		assert.Equal(t, module.Data["tfe_team"]["teams"], TeamDataResource{
@@ -380,12 +380,12 @@ func TestAppendTeamAccess(t *testing.T) {
 			ForEach: map[string]tfeprovider.TeamAccess{
 				"workspace-${data.tfe_team.teams[\"Writers\"].id}": {
 					TeamID:      "${data.tfe_team.teams[\"Writers\"].id}",
-					WorkspaceID: "${tfe_workspace.workspace[\"workspace\"].id}",
+					WorkspaceID: "${tfe_workspace.workspace[\"default\"].id}",
 					Access:      "write",
 				},
 				"workspace-${data.tfe_team.teams[\"Readers\"].id}": {
 					TeamID:      "${data.tfe_team.teams[\"Readers\"].id}",
-					WorkspaceID: "${tfe_workspace.workspace[\"workspace\"].id}",
+					WorkspaceID: "${tfe_workspace.workspace[\"default\"].id}",
 					Access:      "read",
 				},
 			},
@@ -411,7 +411,7 @@ func TestAppendTeamAccess(t *testing.T) {
 		module := NewModule()
 
 		AppendTeamAccess(module, TeamAccess{
-			{TeamName: "Readers", Workspace: &Workspace{Name: "workspace"}, Permissions: &TeamAccessPermissionsInput{
+			{TeamName: "Readers", Workspace: &Workspace{Name: "workspace", Workspace: "default"}, Permissions: &TeamAccessPermissionsInput{
 				Runs:             "read",
 				Variables:        "read",
 				StateVersions:    "none",
@@ -430,7 +430,7 @@ func TestAppendTeamAccess(t *testing.T) {
 		assert.Equal(t, module.Resources["tfe_team_access"]["teams"].(tfeprovider.TeamAccess).ForEach, map[string]tfeprovider.TeamAccess{
 			"workspace-${data.tfe_team.teams[\"Readers\"].id}": {
 				TeamID:      "${data.tfe_team.teams[\"Readers\"].id}",
-				WorkspaceID: "${tfe_workspace.workspace[\"workspace\"].id}",
+				WorkspaceID: "${tfe_workspace.workspace[\"default\"].id}",
 				Access:      "",
 				Permissions: &tfeprovider.TeamAccessPermissions{
 					Runs:             "read",


### PR DESCRIPTION
To support TFE workspace renaming, the workspace resource address name should remain consistent between workspace name changes. To accomplish this, we can use the terraform workspace instead of the workspace name in the resource address.

This is a breaking change, as it will prompt current workspaces in state to be replaced. 