### PR TITLE
Ensure backend copy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,8 @@ jobs:
       #     TF_ORGANIZATION: takescoop-oss
       #   run: go test -v ./...
 
+
+
       - name: Timestamp
         id: timestamp
         run: echo "::set-output name=timestamp::$(date +%s)"
@@ -43,6 +45,7 @@ jobs:
       - name: E2E test
         uses: ./
         with:
+          runner_terraform_version: '1.0.5'
           terraform_organization: takescoop-oss
           terraform_token: ${{ secrets.TF_TOKEN_OSS }}
           name: "action-e2e-test-${{ steps.timestamp.outputs.timestamp }}"
@@ -72,11 +75,13 @@ jobs:
           backend_config: |-
             local:
               path: /github/workspace/terraform.tfstate
+      - uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: '1.0.5'              
+          cli_config_credentials_token: ${{ secrets.TF_TOKEN_OSS }}
       - name: E2E cleanup     
         run: |
-          echo '/github/home:'
-          ls -lah /home/runner/work/_temp/_github_home
-          echo '/github/workflow:'
-          ls -lah /home/runner/work/_temp/_github_workflow
-          echo '/github/workspace'
-          ls -lah /home/runner/work/terraform-cloud-workspace-action/terraform-cloud-workspace-action
+          terraform destroy \
+            -auto-approve \
+            -state=/home/runner/work/terraform-cloud-workspace-action/terraform-cloud-workspace-action/terraform.tfstate \
+            -input=false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,5 +87,5 @@ jobs:
               --header "Authorization: Bearer $TF_TOKEN" \
               --header "Content-Type: application/vnd.api+json" \
               --request DELETE \
-              "https://app.terraform.io/api/v2/worganizations/takescoop-oss/workspaces/${{ steps.e2e-ws-name.outputs.name }}-$ws"
+              "https://app.terraform.io/api/v2/organizations/takescoop-oss/workspaces/${{ steps.e2e-ws-name.outputs.name }}-$ws"
           done

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,7 +89,7 @@ jobs:
             | jq -r '.data[].id')
 
           for id in $ids ; do
-            curl \
+            curl -fsS \
               --header "Authorization: Bearer $TF_TOKEN" \
               --header "Content-Type: application/vnd.api+json" \
               --request DELETE \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,11 +36,11 @@ jobs:
           TF_ORGANIZATION: takescoop-oss
         run: go test -v ./...
 
-      - name: E2E workspace name
+      - name: "E2E: Workspace name"
         id: e2e-ws-name
         run: echo "::set-output name=name::action-e2e-test-$(date +%s)"
 
-      - name: E2E test
+      - name: "E2E: test"
         uses: ./
         with:
           runner_terraform_version: '1.0.5'
@@ -73,14 +73,14 @@ jobs:
           backend_config: |-
             local:
               path: /github/workspace/terraform.tfstate
-      - name: Assert & Cleanup E2E
+      - name: "E2E: Assert & Cleanup"
         env:
           TF_TOKEN: ${{ secrets.TF_TOKEN_OSS }}
         shell: bash
         run: |
           set -e
 
-          stat terraform.tfstate
+          stat terraform.tfstate && echo "Success: state file present"
 
           for ws in staging production ; do
             curl -fsS \
@@ -88,4 +88,5 @@ jobs:
               --header "Content-Type: application/vnd.api+json" \
               --request DELETE \
               "https://app.terraform.io/api/v2/organizations/takescoop-oss/workspaces/${{ steps.e2e-ws-name.outputs.name }}-$ws"
+             echo "Success: Found and deleted ${{ steps.e2e-ws-name.outputs.name }}-$ws"
           done

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,4 +84,5 @@ jobs:
           terraform destroy \
             -auto-approve \
             -state=/home/runner/work/terraform-cloud-workspace-action/terraform-cloud-workspace-action/terraform.tfstate \
-            -input=false
+            -input=false \
+            -lock=false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,9 +38,9 @@ jobs:
 
 
 
-      - name: Timestamp
-        id: timestamp
-        run: echo "::set-output name=timestamp::$(date +%s)"
+      - name: E2E workspace name
+        id: e2e-ws-name
+        run: echo "::set-output name=name::action-e2e-test-$(date +%s)"
 
       - name: E2E test
         uses: ./
@@ -48,7 +48,7 @@ jobs:
           runner_terraform_version: '1.0.5'
           terraform_organization: takescoop-oss
           terraform_token: ${{ secrets.TF_TOKEN_OSS }}
-          name: "action-e2e-test-${{ steps.timestamp.outputs.timestamp }}"
+          name: ${{ steps.e2e-ws-name.outputs.name }}
           tags: |-
             - terraform:true
           workspace_tags: |-
@@ -75,14 +75,23 @@ jobs:
           backend_config: |-
             local:
               path: /github/workspace/terraform.tfstate
-      - uses: hashicorp/setup-terraform@v1
-        with:
-          terraform_version: '1.0.5'              
-          cli_config_credentials_token: ${{ secrets.TF_TOKEN_OSS }}
-      - name: E2E cleanup     
+      - name: Cleanup E2E
+        env:
+          TF_TOKEN: ${{ secrets.TF_TOKEN_OSS }}
+        shell: bash
         run: |
-          terraform destroy \
-            -auto-approve \
-            -state=/home/runner/work/terraform-cloud-workspace-action/terraform-cloud-workspace-action/terraform.tfstate \
-            -input=false \
-            -lock=false
+          set -e
+
+          ids=$(curl -fsS \
+            --header "Authorization: Bearer $TF_TOKEN" \
+            --header "Content-Type: application/vnd.api+json" \
+            https://app.terraform.io/api/v2/organizations/takescoop-oss/workspaces?search[name]=${{ steps.e2e-ws-name.outputs.name }} \
+            | jq -r '.data[].id')
+
+          for id in $ids ; do
+            curl \
+              --header "Authorization: Bearer $TF_TOKEN" \
+              --header "Content-Type: application/vnd.api+json" \
+              --request DELETE \
+              "https://app.terraform.io/api/v2/workspaces/$id"
+          done

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,13 +80,13 @@ jobs:
         run: |
           set -e
 
-          stat terraform.tfstate && echo "Success: state file present"
+          stat terraform.tfstate > /dev/null && echo "Success: state file present"
 
           for ws in staging production ; do
             curl -fsS \
               --header "Authorization: Bearer $TF_TOKEN" \
               --header "Content-Type: application/vnd.api+json" \
               --request DELETE \
-              "https://app.terraform.io/api/v2/organizations/takescoop-oss/workspaces/${{ steps.e2e-ws-name.outputs.name }}-$ws"
+              "https://app.terraform.io/api/v2/organizations/takescoop-oss/workspaces/${{ steps.e2e-ws-name.outputs.name }}-$ws" > /dev/null
              echo "Success: Found and deleted ${{ steps.e2e-ws-name.outputs.name }}-$ws"
           done

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,23 +15,68 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
 
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.16
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
 
-    - name: Test
-      env:
-        TF_TOKEN: ${{ secrets.TF_TOKEN_OSS }}
-        TF_ORGANIZATION: takescoop-oss
-      run: go test -v ./...
+      # - name: Test
+      #   env:
+      #     TF_TOKEN: ${{ secrets.TF_TOKEN_OSS }}
+      #     TF_ORGANIZATION: takescoop-oss
+      #   run: go test -v ./...
+
+      - name: Timestamp
+        id: timestamp
+        run: echo "::set-output name=timestamp::$(date +%s)"
+
+      - name: E2E test
+        uses: ./
+        with:
+          terraform_organization: takescoop-oss
+          terraform_token: ${{ secrets.TF_TOKEN_OSS }}
+          name: "action-e2e-test-${{ steps.timestamp.outputs.timestamp }}"
+          tags: |-
+            - terraform:true
+          workspace_tags: |-
+            staging:
+              - environment:staging
+            production:
+              - environment:production
+          apply: true
+          variables: |-
+            - key: foo
+              value: bar
+              category: terraform
+          workspace_variables: |-
+            staging:
+              - key: environment
+                value: staging
+                category: terraform
+              - key: environment
+                value: production
+                category: terraform
+          workspaces: |-
+            - staging
+            - production
+          backend_config: |-
+            local:
+              path: /github/workspace/terraform.tfstate
+      - name: E2E cleanup     
+        run: |
+          echo '/github/home:'
+          ls -lah /home/runner/work/_temp/_github_home
+          echo '/github/workflow:'
+          ls -lah /home/runner/work/_temp/_github_workflow
+          echo '/github/workspace'
+          ls -lah /home/runner/work/terraform-cloud-workspace-action/terraform-cloud-workspace-action

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,13 +30,11 @@ jobs:
         with:
           go-version: 1.16
 
-      # - name: Test
-      #   env:
-      #     TF_TOKEN: ${{ secrets.TF_TOKEN_OSS }}
-      #     TF_ORGANIZATION: takescoop-oss
-      #   run: go test -v ./...
-
-
+      - name: Test
+        env:
+          TF_TOKEN: ${{ secrets.TF_TOKEN_OSS }}
+          TF_ORGANIZATION: takescoop-oss
+        run: go test -v ./...
 
       - name: E2E workspace name
         id: e2e-ws-name
@@ -75,23 +73,19 @@ jobs:
           backend_config: |-
             local:
               path: /github/workspace/terraform.tfstate
-      - name: Cleanup E2E
+      - name: Assert & Cleanup E2E
         env:
           TF_TOKEN: ${{ secrets.TF_TOKEN_OSS }}
         shell: bash
         run: |
           set -e
 
-          ids=$(curl -fsS \
-            --header "Authorization: Bearer $TF_TOKEN" \
-            --header "Content-Type: application/vnd.api+json" \
-            https://app.terraform.io/api/v2/organizations/takescoop-oss/workspaces?search[name]=${{ steps.e2e-ws-name.outputs.name }} \
-            | jq -r '.data[].id')
+          stat terraform.tfstate
 
-          for id in $ids ; do
+          for ws in staging production ; do
             curl -fsS \
               --header "Authorization: Bearer $TF_TOKEN" \
               --header "Content-Type: application/vnd.api+json" \
               --request DELETE \
-              "https://app.terraform.io/api/v2/workspaces/$id"
+              "https://app.terraform.io/api/v2/worganizations/takescoop-oss/workspaces/${{ steps.e2e-ws-name.outputs.name }}-$ws"
           done

--- a/internal/action/import.go
+++ b/internal/action/import.go
@@ -219,6 +219,10 @@ func ImportTeamAccess(ctx context.Context, tf TerraformCLI, client *tfe.Client, 
 func ImportWorkspaceResources(ctx context.Context, client *tfe.Client, tf *tfexec.Terraform, filePath string, workspace *Workspace, organization string, providers []Provider) error {
 	module := NewModule()
 
+	if err := TerraformInit(ctx, tf, module, filePath); err != nil {
+		return err
+	}
+
 	wsConfig, err := NewWorkspaceResource(ctx, client, []*Workspace{workspace}, &WorkspaceResourceOptions{})
 	if err != nil {
 		return err
@@ -274,10 +278,9 @@ func ImportResources(ctx context.Context, client *tfe.Client, tf *tfexec.Terrafo
 		if err := ImportWorkspaceResources(ctx, client, tf, filePath, ws, organization, providers); err != nil {
 			return err
 		}
-	}
-
-	if err := TerraformInit(ctx, tf, module, filePath); err != nil {
-		return err
+		if err := TerraformInit(ctx, tf, module, filePath); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/internal/action/import.go
+++ b/internal/action/import.go
@@ -219,10 +219,6 @@ func ImportTeamAccess(ctx context.Context, tf TerraformCLI, client *tfe.Client, 
 func ImportWorkspaceResources(ctx context.Context, client *tfe.Client, tf *tfexec.Terraform, filePath string, workspace *Workspace, organization string, providers []Provider) error {
 	module := NewModule()
 
-	if err := TerraformInit(ctx, tf, module, filePath); err != nil {
-		return err
-	}
-
 	wsConfig, err := NewWorkspaceResource(ctx, client, []*Workspace{workspace}, &WorkspaceResourceOptions{})
 	if err != nil {
 		return err
@@ -248,7 +244,7 @@ func ImportWorkspaceResources(ctx context.Context, client *tfe.Client, tf *tfexe
 
 	AddProviders(module, providers)
 
-	if err := WriteModuleFile(module, filePath); err != nil {
+	if err := TerraformInit(ctx, tf, module, filePath); err != nil {
 		return err
 	}
 

--- a/internal/action/import.go
+++ b/internal/action/import.go
@@ -278,6 +278,7 @@ func ImportResources(ctx context.Context, client *tfe.Client, tf *tfexec.Terrafo
 		if err := ImportWorkspaceResources(ctx, client, tf, filePath, ws, organization, providers); err != nil {
 			return err
 		}
+
 		if err := TerraformInit(ctx, tf, module, filePath); err != nil {
 			return err
 		}

--- a/internal/action/import.go
+++ b/internal/action/import.go
@@ -276,7 +276,7 @@ func ImportResources(ctx context.Context, client *tfe.Client, tf *tfexec.Terrafo
 		}
 	}
 
-	if err := WriteModuleFile(module, filePath); err != nil {
+	if err := TerraformInit(ctx, tf, module, filePath); err != nil {
 		return err
 	}
 

--- a/internal/action/main.go
+++ b/internal/action/main.go
@@ -229,8 +229,11 @@ func Run(config *Inputs) error {
 	}
 
 	if !config.Apply {
-		if err = CopyStateToBackend(ctx, tf, module, nil, filePath); err != nil {
-			return fmt.Errorf("failed to copy state to a local backend: %w", err)
+		// copy state to local backend to avoid mutating state when apply=false
+		module.Terraform.Backend = nil
+
+		if err = TerraformInit(ctx, tf, module, filePath); err != nil {
+			return fmt.Errorf("failed to initialize the Terraform configuration: %w", err)
 		}
 	}
 

--- a/internal/action/terraform.go
+++ b/internal/action/terraform.go
@@ -22,9 +22,11 @@ func NewTerraformExec(ctx context.Context, workDir string, version string) (*tfe
 
 // CopyStateToBackend copies state from the current backend to the passed backend by running Terraform Init
 func CopyStateToBackend(ctx context.Context, tf *tfexec.Terraform, module *tfconfig.Module, backend map[string]interface{}, filePath string) error {
-	module.Terraform.Backend = backend
+	mod := module
 
-	if err := TerraformInit(ctx, tf, module, filePath); err != nil {
+	mod.Terraform.Backend = backend
+
+	if err := TerraformInit(ctx, tf, mod, filePath); err != nil {
 		return err
 	}
 

--- a/internal/action/terraform.go
+++ b/internal/action/terraform.go
@@ -22,11 +22,9 @@ func NewTerraformExec(ctx context.Context, workDir string, version string) (*tfe
 
 // CopyStateToBackend copies state from the current backend to the passed backend by running Terraform Init
 func CopyStateToBackend(ctx context.Context, tf *tfexec.Terraform, module *tfconfig.Module, backend map[string]interface{}, filePath string) error {
-	mod := module
+	module.Terraform.Backend = backend
 
-	mod.Terraform.Backend = backend
-
-	if err := TerraformInit(ctx, tf, mod, filePath); err != nil {
+	if err := TerraformInit(ctx, tf, module, filePath); err != nil {
 		return err
 	}
 

--- a/internal/action/terraform.go
+++ b/internal/action/terraform.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/hashicorp/terraform-exec/tfexec"
 	"github.com/hashicorp/terraform-exec/tfinstall"
-	"github.com/takescoop/terraform-cloud-workspace-action/internal/tfconfig"
 )
 
 func NewTerraformExec(ctx context.Context, workDir string, version string) (*tfexec.Terraform, error) {
@@ -18,15 +17,4 @@ func NewTerraformExec(ctx context.Context, workDir string, version string) (*tfe
 	}
 
 	return tfexec.NewTerraform(workDir, execPath)
-}
-
-// CopyStateToBackend copies state from the current backend to the passed backend by running Terraform Init
-func CopyStateToBackend(ctx context.Context, tf *tfexec.Terraform, module *tfconfig.Module, backend map[string]interface{}, filePath string) error {
-	module.Terraform.Backend = backend
-
-	if err := TerraformInit(ctx, tf, module, filePath); err != nil {
-		return err
-	}
-
-	return nil
 }


### PR DESCRIPTION
Fixes a bug where we are not writing the final state to the passed backend.

This fix inclued two changes, I think which makes the code easier to reason about.

Changes:

1) **before**: always copy to empty backend and only copy back to the provided backend at the end if apply.
**now**: switch to empty backend after init only if !apply. It was a bit confusing wondering whether the backend was empty or not at which point. This way theres one logic branch where, after loading state from the passed backend, we either switch or we do not.

1) **before**: was stingy about ensuring when state was copied, writing the import files locally without copying state over first to save some time (harder to reason about what to do when)
**now** use tf init exclusively to ensure that state is predictably transferred between backends, remove wrapper `CopyStateToBackend` function in favor of TerraformInit with a comment, as it's more direct to what's really happening.

Added an E2E test and was aiming to use terraform destroy, but I think we get a little more coverage by intentionally deleting the resources we created. Open to improvements.

closes #80 
