### PR TITLE
Cleanup integration tests

### DIFF
--- a/internal/action/main_test.go
+++ b/internal/action/main_test.go
@@ -67,7 +67,7 @@ func removeTestWorkspaces(t *testing.T, ctx context.Context, client *tfe.Client,
 
 	for _, ws := range workspaces.Items {
 		err := client.Workspaces.DeleteByID(ctx, ws.ID)
-		assert.NoError(err)
+		assert.NoError(t, err)
 	}
 }
 

--- a/internal/action/main_test.go
+++ b/internal/action/main_test.go
@@ -68,7 +68,7 @@ func removeTestWorkspaces(t *testing.T, ctx context.Context, client *tfe.Client,
 
 	for _, ws := range workspaces.Items {
 		err := client.Workspaces.DeleteByID(ctx, ws.ID)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}
 }
 


### PR DESCRIPTION
moves from `if err != nil {t.Fatal(err)}` to `assert.NoError(t, err)`. I think it reads better in these tests and it's technically what we want ("make sure there's no error here")