### PR TITLE
Fetch variables once in import

### DIFF
--- a/internal/action/import.go
+++ b/internal/action/import.go
@@ -265,9 +265,8 @@ func ImportWorkspaceResources(ctx context.Context, client *tfe.Client, tf *tfexe
 		return err
 	}
 
-	for _, v := range variables {
-		err := ImportVariable(ctx, tf, v, workspace, organization)
-		if err != nil {
+	for _, variable := range variables {
+		if err := ImportVariable(ctx, tf, variable, workspace, organization); err != nil {
 			return err
 		}
 	}

--- a/internal/action/import.go
+++ b/internal/action/import.go
@@ -92,13 +92,13 @@ func fetchVariableByKey(ctx context.Context, client *tfe.Client, key string, wor
 }
 
 // ImportVariable imports the passed variable into Terraform state
-func ImportVariable(ctx context.Context, tf TerraformCLI, client *tfe.Client, key string, workspace *Workspace, organization string, opts ...tfexec.ImportOption) error {
+func ImportVariable(ctx context.Context, tf TerraformCLI, v *tfe.Variable, workspace *Workspace, organization string, opts ...tfexec.ImportOption) error {
 	if workspace.ID == nil {
 		githubactions.Infof("Workspace %q not found, skipping import\n", workspace.Name)
 		return nil
 	}
 
-	address := fmt.Sprintf("tfe_variable.%s-%s", workspace.Workspace, key)
+	address := fmt.Sprintf("tfe_variable.%s-%s", workspace.Workspace, v.Key)
 
 	imp, err := shouldImport(ctx, tf, address)
 	if err != nil {
@@ -111,16 +111,6 @@ func ImportVariable(ctx context.Context, tf TerraformCLI, client *tfe.Client, ke
 	}
 
 	githubactions.Infof("Importing variable: %q\n", address)
-
-	v, err := fetchVariableByKey(ctx, client, key, *workspace.ID, 1)
-	if err != nil {
-		return err
-	}
-
-	if v == nil {
-		githubactions.Infof("Variable %q for workspace %q not found, skipping import\n", key, workspace.Name)
-		return nil
-	}
 
 	importID := fmt.Sprintf("%s/%s/%s", organization, workspace.Name, v.ID)
 
@@ -263,13 +253,15 @@ func ImportWorkspaceResources(ctx context.Context, client *tfe.Client, tf *tfexe
 
 	module.AppendResource("tfe_workspace", "workspace", wsConfig)
 
-	variables, err := FindRelatedVariables(ctx, client, workspace, organization)
+	variables, err := FetchRelatedVariables(ctx, client, workspace)
 	if err != nil {
 		return err
 	}
 
-	for _, v := range variables {
-		module.AppendResource("tfe_variable", fmt.Sprintf("%s-%s", v.Workspace.Workspace, v.Key), v.ToResource())
+	for _, variable := range variables {
+		v := ToVariable(variable, workspace)
+
+		module.AppendResource("tfe_variable", fmt.Sprintf("%s-%s", workspace.Workspace, v.Key), v.ToResource())
 	}
 
 	teamAccess, err := FindRelatedTeamAccess(ctx, client, workspace, organization)
@@ -297,7 +289,7 @@ func ImportWorkspaceResources(ctx context.Context, client *tfe.Client, tf *tfexe
 	}
 
 	for _, v := range variables {
-		err := ImportVariable(ctx, tf, client, v.Key, v.Workspace, organization)
+		err := ImportVariable(ctx, tf, v, workspace, organization)
 		if err != nil {
 			return err
 		}

--- a/internal/action/import.go
+++ b/internal/action/import.go
@@ -68,29 +68,6 @@ func ImportWorkspace(ctx context.Context, tf TerraformCLI, client *tfe.Client, w
 	return nil
 }
 
-func fetchVariableByKey(ctx context.Context, client *tfe.Client, key string, workspaceID string, page int) (*tfe.Variable, error) {
-	vs, err := client.Variables.List(ctx, workspaceID, tfe.VariableListOptions{
-		ListOptions: tfe.ListOptions{
-			PageSize: maxPageSize,
-		},
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	for _, v := range vs.Items {
-		if v.Key == key {
-			return v, nil
-		}
-	}
-
-	if vs.NextPage > page {
-		return fetchVariableByKey(ctx, client, key, workspaceID, vs.NextPage)
-	}
-
-	return nil, nil
-}
-
 // ImportVariable imports the passed variable into Terraform state
 func ImportVariable(ctx context.Context, tf TerraformCLI, v *tfe.Variable, workspace *Workspace, organization string, opts ...tfexec.ImportOption) error {
 	if workspace.ID == nil {

--- a/internal/action/import_test.go
+++ b/internal/action/import_test.go
@@ -339,38 +339,6 @@ func TestImportRelatedRunTriggers(t *testing.T) {
 	})
 }
 
-var varsAPIResponse = `{
-  "data": [
-    {
-      "id": "var-abc123",
-      "type": "vars",
-      "attributes": {
-        "key": "foo",
-        "value": "bar",
-        "sensitive": false,
-        "category": "env",
-        "hcl": false,
-        "created-at": "2021-08-30T16:01:07.885Z",
-        "description": null
-      },
-      "relationships": {
-        "configurable": {
-          "data": {
-            "id": "ws-abc123",
-            "type": "workspaces"
-          },
-          "links": {
-            "related": "/api/v2/organizations/org/workspaces/ws"
-          }
-        }
-      },
-      "links": {
-        "self": "/api/v2/workspaces/ws-abc123/vars/var-abc123"
-      }
-    }
-  ]
-}`
-
 var teamAccessAPIResponse = `{
   "data": [
     {


### PR DESCRIPTION
As [referenced](https://github.com/TakeScoop/terraform-cloud-workspace-action/pull/87#discussion_r710428099) in a previous commit, there is some unneeded logic in the import functionality after switching to drift correction.

Before, a user would submit a list of variables, the steps would be:
- see if workspace exists
- see if variable exists
- import variable

Now, because we don't rely on user inputs for imports anymore, we can ask Terraform for a list of existing resources and import those. This also implies that workspace exists, so the steps boil down to:
- fetch all related variables
- import variables

Got to remove a handful of unused functions as a result 🥳 