### PR TITLE
Fetch related team access and teams once for importing

### DIFF
--- a/internal/action/team_access_test.go
+++ b/internal/action/team_access_test.go
@@ -1,9 +1,6 @@
 package action
 
 import (
-	"context"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -81,61 +78,4 @@ func TestNewTeamAccess(t *testing.T) {
 			assert.Equal(t, access, testCase.Expect)
 		})
 	}
-}
-
-func TestFindRelatedTeamAccess(t *testing.T) {
-	t.Run("team access found", func(t *testing.T) {
-		ctx := context.Background()
-
-		mux := http.NewServeMux()
-		server := httptest.NewServer(mux)
-
-		t.Cleanup(func() {
-			server.Close()
-		})
-
-		mux.HandleFunc("/api/v2/organizations/org/teams", testServerResHandler(t, 200, teamAPIResponse))
-		mux.HandleFunc("/api/v2/team-workspaces", testServerResHandler(t, 200, teamAccessAPIResponse))
-
-		client := newTestTFClient(t, server.URL)
-
-		workspace := &Workspace{Name: "ws", Workspace: "default", ID: strPtr("ws-abc123")}
-		access, err := FindRelatedTeamAccess(ctx, client, workspace, "org")
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		assert.Equal(t, len(access), 1)
-		assert.Equal(t, access, TeamAccess{
-			{
-				TeamName:  "Readers",
-				Access:    "write",
-				Workspace: workspace,
-			},
-		})
-	})
-
-	t.Run("no team access found", func(t *testing.T) {
-		ctx := context.Background()
-
-		mux := http.NewServeMux()
-		server := httptest.NewServer(mux)
-
-		t.Cleanup(func() {
-			server.Close()
-		})
-
-		mux.HandleFunc("/api/v2/organizations/org/teams", testServerResHandler(t, 200, `{"data": []}`))
-		mux.HandleFunc("/api/v2/team-workspaces", testServerResHandler(t, 200, `{"data": []}`))
-
-		client := newTestTFClient(t, server.URL)
-
-		workspace := &Workspace{Name: "ws", Workspace: "default", ID: strPtr("ws-abc123")}
-		access, err := FindRelatedTeamAccess(ctx, client, workspace, "org")
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		assert.Equal(t, len(access), 0)
-	})
 }


### PR DESCRIPTION
Ensures teams and team access resources are fetched once on import.

Before:
fetch teams and team access resources -> convert to terraform configuration
fetch teams and team access resources -> import resources

Now:
fetch teams and team access resources 
convert to terraform configuration
import resources