### PR TITLE
Mask sensitive variable values

### DIFF
--- a/internal/action/main.go
+++ b/internal/action/main.go
@@ -141,6 +141,8 @@ func Run(config *Inputs) error {
 		}
 	}
 
+	variables.MaskSensitive()
+
 	for wsName, wvs := range wsVars {
 		ws := FindWorkspace(workspaces, wsName)
 

--- a/internal/action/main.go
+++ b/internal/action/main.go
@@ -141,8 +141,6 @@ func Run(config *Inputs) error {
 		}
 	}
 
-	variables.MaskSensitive()
-
 	for wsName, wvs := range wsVars {
 		ws := FindWorkspace(workspaces, wsName)
 
@@ -154,6 +152,8 @@ func Run(config *Inputs) error {
 			variables = append(variables, *NewVariable(v, ws))
 		}
 	}
+
+	variables.MaskSensitive()
 
 	var teamInputs TeamAccessInput
 

--- a/internal/action/variable.go
+++ b/internal/action/variable.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	tfe "github.com/hashicorp/go-tfe"
+	"github.com/sethvargo/go-githubactions"
 	"github.com/takescoop/terraform-cloud-workspace-action/internal/tfeprovider"
 )
 
@@ -41,6 +42,19 @@ func NewVariable(vi VariablesInputItem, w *Workspace) *Variable {
 		Sensitive:   vi.Sensitive,
 		Workspace:   w,
 	}
+}
+
+func (vs Variables) MaskSensitive() {
+	for _, v := range vs {
+		if v.Sensitive {
+			v.Mask()
+		}
+	}
+}
+
+func (v Variable) Mask() {
+	githubactions.Debugf("Masking variable %q\n", v.Key)
+	githubactions.AddMask(v.Value)
 }
 
 // ToResource converts a variable to a Terraform variable resource

--- a/internal/action/variable.go
+++ b/internal/action/variable.go
@@ -44,6 +44,7 @@ func NewVariable(vi VariablesInputItem, w *Workspace) *Variable {
 	}
 }
 
+// MaskSensitive masks all sensitive variable values in the GitHub Actions log output
 func (vs Variables) MaskSensitive() {
 	for _, v := range vs {
 		if v.Sensitive {
@@ -52,6 +53,7 @@ func (vs Variables) MaskSensitive() {
 	}
 }
 
+// Mask masks a variable's value in the GitHub Actions log output
 func (v Variable) Mask() {
 	githubactions.Debugf("Masking variable %q\n", v.Key)
 	githubactions.AddMask(v.Value)


### PR DESCRIPTION
This helps mask sensitive variables so that values are redacted from log output for the duration of at least the step, but possibly the job.

https://docs.github.com/en/actions/reference/encrypted-secrets#naming-your-secrets

> To help ensure that GitHub redacts your secret in logs, avoid using structured data as the values of secrets. For example, avoid creating secrets that contain JSON or encoded Git blobs.

> Warning: GitHub automatically redacts secrets printed to the log, but you should avoid printing secrets to the log intentionally.

The idea here is that if you have a JSON secret with a `private_key` key, decode it, and then `fmt.Println(credentials.PrivateKey)`, that won't be masked. But there's a security vs. convenience/functionality trade-off here, Actions doesn't have typed inputs, so some decoding is inevitable.

When Actions runs your workflow, it knows which secrets it refers to and masks the values that are injected automatically. But you might get a sensitive value from another step/job output rather than a simple `secrets` reference. 

This adds a bit of extra protection against printing sensitive values to logs by masking them after they're unmarshaled/merged. Terraform itself will redact the values in the plan text. Unmarshaling errors should only contain type info and not any of the input data. 

This is preventative and not in response to any specific observed log output.