### PR TITLE
Add execution_mode default "remote"

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -65,6 +65,7 @@ inputs:
     description: ID of an agent pool to assign to the workspace. If passed, execution_mode is set to "agent".
   execution_mode:
     description: Execution mode to use for the workspace.
+    default: remote
   global_remote_state: 
     description: Whether all workspaces in the organization can access the workspace via remote state.
     default: false


### PR DESCRIPTION
Adds a default to the execution_mode. This allows for a more intuitive experience when removing a Terraform Cloud Agent ID. See https://github.com/TakeScoop/harbormaster/pull/865#discussion_r807276176 for more details