### PR TITLE
Remove explicit tfe provider token

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM golang:alpine AS build
+FROM golang:1.18-alpine AS build
+
+RUN apk add git
 
 WORKDIR /src
 COPY . ./

--- a/internal/action/main.go
+++ b/internal/action/main.go
@@ -78,8 +78,8 @@ func Run(config *Inputs) error {
 		return fmt.Errorf("failed to create tfexec instance: %w", err)
 	}
 
-	b := []byte(fmt.Sprintf(`credentials "%s" {
-	token = "%s" 
+	b := []byte(fmt.Sprintf(`credentials %q {
+	token = %q
 }`, config.Host, config.Token))
 
 	home, err := os.UserHomeDir()

--- a/internal/action/main.go
+++ b/internal/action/main.go
@@ -213,7 +213,6 @@ func Run(config *Inputs) error {
 			Source:  "hashicorp/tfe",
 			Config: tfeprovider.Config{
 				Hostname: config.Host,
-				Token:    config.Token,
 			},
 		},
 	}

--- a/internal/action/main.go
+++ b/internal/action/main.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
-	"strings"
 
 	"github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-exec/tfexec"
@@ -79,7 +78,7 @@ func Run(config *Inputs) error {
 		return fmt.Errorf("failed to create tfexec instance: %w", err)
 	}
 
-	if err := writeTerraformrcFile(map[string]string{config.Host: config.Token}); err != nil {
+	if err := writeTerraformrcFile(config.Host, config.Token); err != nil {
 		return fmt.Errorf("failed to write .terraformrc file")
 	}
 
@@ -309,28 +308,6 @@ func Run(config *Inputs) error {
 		}
 	} else {
 		githubactions.Infof("No changes\n")
-	}
-
-	return nil
-}
-
-func writeTerraformrcFile(hostTokens map[string]string) error {
-	var entries []string
-
-	for host, token := range hostTokens {
-		entries = append(entries, fmt.Sprintf(`credentials %q { token = %q	}`, host, token))
-	}
-
-	b := []byte(strings.Join(entries, "\n"))
-
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return fmt.Errorf("failed to retrieve homedir: %w", err)
-	}
-
-	err = ioutil.WriteFile(path.Join(home, ".terraformrc"), b, 0644)
-	if err != nil {
-		return fmt.Errorf("failed to write Terraform Cloud credentials to home directory: %w", err)
 	}
 
 	return nil

--- a/internal/action/terraform.go
+++ b/internal/action/terraform.go
@@ -2,6 +2,10 @@ package action
 
 import (
 	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
 
 	"github.com/hashicorp/terraform-exec/tfexec"
 	"github.com/hashicorp/terraform-exec/tfinstall"
@@ -17,4 +21,20 @@ func NewTerraformExec(ctx context.Context, workDir string, version string) (*tfe
 	}
 
 	return tfexec.NewTerraform(workDir, execPath)
+}
+
+func writeTerraformrcFile(host string, token string) error {
+	b := []byte(fmt.Sprintf(`credentials %q { token = %q	}`, host, token))
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("failed to retrieve homedir: %w", err)
+	}
+
+	err = ioutil.WriteFile(path.Join(home, ".terraformrc"), b, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to write Terraform Cloud credentials to home directory: %w", err)
+	}
+
+	return nil
 }

--- a/internal/action/workspace.go
+++ b/internal/action/workspace.go
@@ -326,7 +326,7 @@ func WriteModuleFile(module *tfconfig.Module, filePath string) error {
 	return nil
 }
 
-// TerraformInit updates the current configuration using the passed module and runs Terraform Init
+// TerraformInit updates the current configuration using the passed module and runs "terraform init"
 func TerraformInit(ctx context.Context, tf *tfexec.Terraform, module *tfconfig.Module, filePath string) error {
 	if err := WriteModuleFile(module, filePath); err != nil {
 		return err

--- a/internal/action/workspace.go
+++ b/internal/action/workspace.go
@@ -326,7 +326,7 @@ func WriteModuleFile(module *tfconfig.Module, filePath string) error {
 	return nil
 }
 
-// TerraformInit updates the current configuration usign the passed module and runs Terraform Init
+// TerraformInit updates the current configuration using the passed module and runs Terraform Init
 func TerraformInit(ctx context.Context, tf *tfexec.Terraform, module *tfconfig.Module, filePath string) error {
 	if err := WriteModuleFile(module, filePath); err != nil {
 		return err


### PR DESCRIPTION
This PR removes the explicitly placed Terraform token from the tfe provider configuration in favor of a token sourced from a .terraformrc file.

When using [tfexec ShowPlanFile](https://github.com/hashicorp/terraform-exec/blob/6ff79245078142204b63aa1d9e6c0790c92945f8/tfexec/show.go#L110), the provider configuration is set within the returned tfjson.Plan object which includes the Terraform token in plain text. The plan object is then marshaled into a JSON string and set as an action output. 

```
{
  "format_version": "1.0",
  "terraform_version": "1.1.6",
  "planned_values": {
    "root_module": {}
  },
  "configuration": {
    "provider_config": {
      "tfe": {
        "name": "tfe",
        "expressions": {
          "token": {
            "constant_value": "<token>"
          }
        }
      }
    },
    "root_module": {}
  }
}
```

We are already setting the token in a .terraformrc file which should be enough to cover what the explicit token in the generated provider file was doing.