### PR TITLE
Add git to docker image for go alpine 1.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM golang:alpine AS build
 
+RUN apk add git
+
 WORKDIR /src
 COPY . ./
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine AS build
+FROM golang:1.18-alpine AS build
 
 RUN apk add git
 


### PR DESCRIPTION
go 1.18's alpine image [does not contain the git binary](https://github.com/docker-library/golang/issues/415), which was included in alpine 1.17. With 1.18's release, our [build pipeline fails](https://github.com/TakeScoop/terraform-cloud-workspace-action/runs/5575286265?check_suite_focus=true) because go had been depending on `git` to exist and have jumped to 1.18 because we were not pinning to a go minor version.

Changes
- Add git binary
- Pin to minor 1.18