### PR TITLE
Ensure GobalRemoteState is true

### DIFF
--- a/internal/action/workspace.go
+++ b/internal/action/workspace.go
@@ -132,8 +132,9 @@ func NewWorkspaceResource(ctx context.Context, client *tfe.Client, workspaces []
 	}
 
 	if config.GlobalRemoteState != nil {
+		ws.GlobalRemoteState = config.GlobalRemoteState
+
 		if !*config.GlobalRemoteState {
-			ws.GlobalRemoteState = config.GlobalRemoteState
 			ws.RemoteStateConsumerIDs = strings.FieldsFunc(config.RemoteStateConsumerIDs, func(c rune) bool { return c == ',' })
 		}
 	}

--- a/internal/action/workspace_test.go
+++ b/internal/action/workspace_test.go
@@ -317,6 +317,16 @@ func TestNewWorkspaceResource(t *testing.T) {
 		assert.Equal(t, ws.RemoteStateConsumerIDs, []string{"123", "456", "789"})
 	})
 
+	t.Run("ensure GlobalRemoteState true if passed as true", func(t *testing.T) {
+		ws, err := NewWorkspaceResource(ctx, client, newTestSingleWorkspaceList(), &WorkspaceResourceOptions{
+			Organization:      "org",
+			GlobalRemoteState: boolPtr(true),
+		})
+		require.NoError(t, err)
+
+		assert.Equal(t, *ws.GlobalRemoteState, true)
+	})
+
 	t.Run("add no remote IDs when none are passed", func(t *testing.T) {
 		ws, err := NewWorkspaceResource(ctx, client, newTestSingleWorkspaceList(), &WorkspaceResourceOptions{
 			Organization:      "org",


### PR DESCRIPTION
I noticed that our new cloud workspaces are being set with global_remote_state: false. Poking around, I found a bug in the action where if GlobalRemoteState is true, it is not set on the config. 