### PR TITLE
Bump tfe provider version 0.30.2

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
     required: true
   tfe_provider_version:
     description: Terraform Cloud provider version.
-    default: "0.26.1"
+    default: "0.30.2"
   name:
     description: Name of the workspace. Becomes a prefix if workspaces are passed (`${name}-${workspace}`).
     default: "${{ github.event.repository.name }}"


### PR DESCRIPTION
Bumps the tfe provider version
[0.26.1](https://github.com/hashicorp/terraform-provider-tfe/blob/main/CHANGELOG.md#0261-september-04-2021) -> [0.30.2](https://github.com/hashicorp/terraform-provider-tfe/blob/main/CHANGELOG.md#0302-april-01-2022)