### PR TITLE
action: use latest terraform v1 by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ jobs:
 | `ssh_key_id` | SSH key ID to assign the workspace | |
 | `tags` | YAML encoded list of tag names applied to all workspaces | |
 | `team_access` | YAML encoded teams and their associated permissions to be granted to the created workspaces | `false` |
-| `terraform_version` | Workspace Terraform version | `1.0.3` |
+| `terraform_version` | Workspace Terraform version | `1` |
 | `terraform_host` | Terraform Cloud host | `app.terraform.io` |
 | `tfe_provider_version` | Terraform Cloud provider version | `0.25.3` |
 | `variables` | YAML encoded variables to apply to all workspaces | |

--- a/action.yml
+++ b/action.yml
@@ -2,8 +2,8 @@ name: Terraform Cloud Workspace
 description: Manages Terraform Cloud workspaces
 inputs:
   terraform_version:
-    description: Workspace Terraform version.
-    default: "1.1.8"
+    description: Workspace Terraform version. This can be either an exact version or a version constraint (like ~> 1.0.0). 
+    default: "1"
   terraform_token:
     description: Terraform Cloud token.
     required: true

--- a/internal/action/team_access.go
+++ b/internal/action/team_access.go
@@ -61,6 +61,7 @@ func (ta TeamAccessItem) ToResource() *tfeprovider.TeamAccess {
 			StateVersions:    ta.Permissions.StateVersions,
 			SentinelMocks:    ta.Permissions.SentinelMocks,
 			WorkspaceLocking: ta.Permissions.WorkspaceLocking,
+			RunTasks:         ta.Permissions.RunTasks,
 		}
 	}
 
@@ -73,6 +74,7 @@ type TeamAccessPermissionsInput struct {
 	StateVersions    string `yaml:"state_versions"`
 	SentinelMocks    string `yaml:"sentinel_mocks"`
 	WorkspaceLocking bool   `yaml:"workspace_locking"`
+	RunTasks         bool   `yaml:"run_tasks"`
 }
 
 // findTeamByID takes a list of teams and returns a matching team to the passed ID

--- a/internal/action/workspace.go
+++ b/internal/action/workspace.go
@@ -250,6 +250,7 @@ func AppendTeamAccess(module *tfconfig.Module, teamAccess TeamAccess, organizati
 					StateVersions:    "${each.value.permissions.state_versions}",
 					SentinelMocks:    "${each.value.permissions.sentinel_mocks}",
 					WorkspaceLocking: "${each.value.permissions.workspace_locking}",
+					RunTasks:         "${each.value.permissions.run_tasks}",
 				},
 			}},
 		},

--- a/internal/action/workspace_test.go
+++ b/internal/action/workspace_test.go
@@ -435,6 +435,7 @@ func TestAppendTeamAccess(t *testing.T) {
 						StateVersions:    "${each.value.permissions.state_versions}",
 						SentinelMocks:    "${each.value.permissions.sentinel_mocks}",
 						WorkspaceLocking: "${each.value.permissions.workspace_locking}",
+						RunTasks:         "${each.value.permissions.run_tasks}",
 					},
 				}},
 			},
@@ -451,6 +452,7 @@ func TestAppendTeamAccess(t *testing.T) {
 				StateVersions:    "none",
 				SentinelMocks:    "none",
 				WorkspaceLocking: true,
+				RunTasks:         true,
 			}},
 		}, "org")
 
@@ -472,6 +474,7 @@ func TestAppendTeamAccess(t *testing.T) {
 					StateVersions:    "none",
 					SentinelMocks:    "none",
 					WorkspaceLocking: true,
+					RunTasks:         true,
 				},
 			},
 		})
@@ -737,6 +740,7 @@ func TestNewWorkspaceConfig(t *testing.T) {
 					StateVersions:    "read",
 					SentinelMocks:    "none",
 					WorkspaceLocking: true,
+					RunTasks:         true,
 				}},
 				TeamAccessItem{TeamName: "${data.terraform_remote_state.teams.outputs.team}", Workspace: &Workspace{Name: name}, Access: "read"},
 			},

--- a/internal/tfeprovider/team_access.go
+++ b/internal/tfeprovider/team_access.go
@@ -18,6 +18,7 @@ type TeamAccessPermissions struct {
 	StateVersions    string      `json:"state_versions"`
 	SentinelMocks    string      `json:"sentinel_mocks"`
 	WorkspaceLocking interface{} `json:"workspace_locking"`
+	RunTasks         interface{} `json:"run_tasks"`
 }
 
 type DynamicPermissions struct {


### PR DESCRIPTION
Uses a constraint to select the Terraform version for workspaces. By default, this is set to `1`, using the latest Terraform v1 version. Users are likely to want to narrow their range to a specific minor version instead.